### PR TITLE
feat(track): Allow fill factor as parameter

### DIFF
--- a/docs/tutorial/02-scenario-configuration.md
+++ b/docs/tutorial/02-scenario-configuration.md
@@ -133,6 +133,38 @@ To test different resource allocation approaches:
 - Using `least_occupied` for workshops distributes work evenly, preventing bottlenecks
 - Using `shortest_queue` for workshops minimizes wagon waiting times
 
+### Setting Maximum Fill Levels Per Track Type
+
+To define how much of each track type's physical length should be usable, use `track_type_fill_factors`. This sets a default fill factor for all tracks of a given type:
+
+```json
+{
+  "track_type_fill_factors": {
+    "parking": 0.6,
+    "collection": 0.8,
+    "retrofit": 0.9,
+    "retrofitted": 0.85,
+    "workshop": 1.0
+  }
+}
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `track_type_fill_factors` | object | Maps track type names to fill factor values (0.0 – 1.0) |
+
+**Fill Factor Values:**
+- `1.0` = 100% of physical track length is usable
+- `0.75` = 75% of physical track length is usable (default when not specified)
+- `0.5` = 50% of physical track length is usable
+
+**Precedence:** If an individual track in `tracks.json` specifies its own `fillfactor`, that value takes priority over the type-level default defined here.
+
+**Use Cases:**
+- Set parking tracks to 60% to leave safety margins for shunting operations
+- Set collection tracks to 80% to account for coupling distances
+- Set workshop tracks to 100% since wagons are precisely positioned
+
 ## Validation Rules
 
 - `id` must be unique across scenarios

--- a/docs/tutorial/04-track-configuration.md
+++ b/docs/tutorial/04-track-configuration.md
@@ -28,6 +28,15 @@ Each track definition contains:
 | `name` | string | No | Human-readable track name |
 | `edges` | array[string] | Yes | List of edge IDs from topology.json |
 | `type` | string | Yes | Track type (determines function) |
+| `fillfactor` | float | No | Usable fraction of track length (0.0–1.0). Overrides the type-level default from scenario.json. If not set, uses the value from `track_type_fill_factors` in scenario.json, or 0.75 as final fallback. |
+
+### Per-Track Fill Factor Example
+
+```json
+{"id": "parking1", "edges": ["parking1"], "type": "parking", "fillfactor": 0.5}
+```
+
+This track would only use 50% of its physical length, regardless of the type-level setting in `scenario.json`.
 
 ## Track Types
 

--- a/popupsim/backend/src/contexts/configuration/domain/models/scenario.py
+++ b/popupsim/backend/src/contexts/configuration/domain/models/scenario.py
@@ -77,6 +77,11 @@ class Scenario(BaseModel):
         print(f'DEBUG VALIDATOR: parking_selection_strategy raw value: {v}, type: {type(v)}')
         return v
 
+    track_type_fill_factors: dict[str, float] = Field(
+        default_factory=dict,
+        description='Maximum fill factor per track type (e.g. {"parking": 0.6, "collection": 0.8}). '
+        'Individual track fillfactor values override these defaults.',
+    )
     parking_strategy: str = 'opportunistic'
     parking_normal_threshold: float = 0.3
     parking_critical_threshold: float = 0.8

--- a/popupsim/backend/src/contexts/configuration/infrastructure/file_loader.py
+++ b/popupsim/backend/src/contexts/configuration/infrastructure/file_loader.py
@@ -44,6 +44,7 @@ class FileLoader:  # pylint: disable=too-few-public-methods
             or SelectionStrategy.LEAST_OCCUPIED,
             workshop_selection_strategy=data.get('workshop_selection_strategy') or SelectionStrategy.ROUND_ROBIN,
             parking_selection_strategy=data.get('parking_selection_strategy') or SelectionStrategy.LEAST_OCCUPIED,
+            track_type_fill_factors=data.get('track_type_fill_factors', {}),
             parking_strategy=data.get('parking_strategy', 'opportunistic'),
             parking_normal_threshold=data.get('parking_normal_threshold', 0.3),
             parking_critical_threshold=data.get('parking_critical_threshold', 0.8),
@@ -91,12 +92,14 @@ class FileLoader:  # pylint: disable=too-few-public-methods
                 track_length = t.get(
                     'capacity', t.get('length', sum(edge_lengths.get(edge, 0.0) for edge in t.get('edges', [])))
                 )
+                track_type = t.get('type', 'standard')
+                default_fill = scenario.track_type_fill_factors.get(track_type, 0.75)
                 tracks.append(
                     TrackInputDTO(
                         id=t['id'],
-                        type=t.get('type', 'standard'),
+                        type=track_type,
                         length=track_length,
-                        fillfactor=t.get('fillfactor', 0.75),
+                        fillfactor=t.get('fillfactor', default_fill),
                     )
                 )
             scenario.tracks = tracks
@@ -106,12 +109,14 @@ class FileLoader:  # pylint: disable=too-few-public-methods
             tracks = []
             for t in track_data['tracks']:
                 track_length = t.get('length', sum(edge_lengths.get(edge, 0.0) for edge in t.get('edges', [])))
+                track_type = t.get('type', 'standard')
+                default_fill = scenario.track_type_fill_factors.get(track_type, 0.75)
                 tracks.append(
                     TrackInputDTO(
                         id=t['id'],
-                        type=t.get('type', 'standard'),
+                        type=track_type,
                         length=track_length,
-                        fillfactor=t.get('fillfactor', 0.75),
+                        fillfactor=t.get('fillfactor', default_fill),
                     )
                 )
             scenario.tracks = tracks


### PR DESCRIPTION
## Summary
The fill factor was hardcoded for the tracks. Now it is a parameter and can be set by the user. If not value is specified the default of 75 percent is used. Documentation is properly updated. 

## Related Issues/Tickets
None

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test improvement
- [ ] Other (please describe):

## How Has This Been Tested?
Tested by pytest and a demo scenario

## Checklist
- [x] Follows conventional commit message format
- [x] Code is formatted and linted (`uv run ruff format . && uv run ruff check .`)
- [x] All tests pass (`uv run pytest`)
- [x] Documentation updated (if needed)

## Additional Notes
<!-- Anything else for reviewers to know? Questions, blockers, context. -->
