### PR TITLE
fix(ui): Frequency H deprecated

### DIFF
--- a/popupsim/frontend/dashboard_components/scenario_tab.py
+++ b/popupsim/frontend/dashboard_components/scenario_tab.py
@@ -219,7 +219,7 @@ def _render_schedule_section(analyzer: ScenarioAnalyzer) -> None:
         return
 
     # Create hourly bins
-    train_arrivals['hour'] = train_arrivals['arrival_time'].dt.floor('H')
+    train_arrivals['hour'] = train_arrivals['arrival_time'].dt.floor('h')
     hourly_wagons = train_arrivals.groupby('hour')['wagon_count'].sum()
 
     # Create plotly bar chart


### PR DESCRIPTION
## Summary
On the simulation tab in the frontend an error occured since the frequency H in Pandas is invalid. The error arises because Pandas has deprecated it. Instead the lowercase char h now needs to be used.

## Related Issues/Tickets
None

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test improvement
- [ ] Other (please describe):

## How Has This Been Tested?
Manually tested for 2 scenarios

## Checklist
- [X] Follows conventional commit message format
- [X] Code is formatted and linted (`uv run ruff format . && uv run ruff check .`)
- [X] All tests pass (`uv run pytest`)
- [X] Documentation updated (if needed)

## Additional Notes
Fix is tiny. Only one occurance needs to be changed from H to h
