### PR TITLE
Automatically approve patch and minor version bumps of Pendabot

### DIFF
--- a/.github/workflows/dependabot-automerge-paths.yml
+++ b/.github/workflows/dependabot-automerge-paths.yml
@@ -1,9 +1,8 @@
 name: "Dependabot Auto-merge"
 
-on: 
+on:
   pull_request:
     types: [opened, reopened, synchronize]
-  # Allows you to manually trigger this from the "Actions" tab if needed
   workflow_dispatch:
 
 permissions:
@@ -13,10 +12,8 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    # ✅ FIX: Check if the PR *Owner* is Dependabot, not the person running the workflow.
-    # This allows YOU to click "Re-run" on a Dependabot PR and have it succeed.
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
-    
+
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
@@ -24,10 +21,16 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Enable auto-merge for Patch releases
-        # Only merge if it is a Patch release
-        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
+      - name: Approve PR for Patch and Minor releases
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for Patch and Minor releases
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/popupsim/frontend/dashboard_components/scenario_tab.py
+++ b/popupsim/frontend/dashboard_components/scenario_tab.py
@@ -219,7 +219,7 @@ def _render_schedule_section(analyzer: ScenarioAnalyzer) -> None:
         return
 
     # Create hourly bins
-    train_arrivals['hour'] = train_arrivals['arrival_time'].dt.floor('H')
+    train_arrivals['hour'] = train_arrivals['arrival_time'].dt.floor('h')
     hourly_wagons = train_arrivals.groupby('hour')['wagon_count'].sum()
 
     # Create plotly bar chart


### PR DESCRIPTION
## Summary
Pendabot is allowed to automerge patch and minor versions. But it does not work since always an approver is necessary. Its tried here to let Pendabot approve the merge itself for patch and minor versions. It might be blocked by the rules of ORA when commit author and approver need to be distinct accounts.

## Related Issues/Tickets

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test improvement
- [X] Other (please describe):
CI improvement

## How Has This Been Tested?
Not possible

## Checklist
- [X] Follows conventional commit message format
- [X] Code is formatted and linted (`uv run ruff format . && uv run ruff check .`)
- [X] All tests pass (`uv run pytest`)
- [ ] Documentation updated (if needed)

## Additional Notes

