### PR TITLE
fix: Discard train if no wagons should have retrofig

### DIFF
--- a/popupsim/backend/src/contexts/retrofit_workflow/application/coordinators/arrival_coordinator.py
+++ b/popupsim/backend/src/contexts/retrofit_workflow/application/coordinators/arrival_coordinator.py
@@ -74,7 +74,8 @@ class ArrivalCoordinator(BaseCoordinator):  # pylint: disable=too-many-instance-
         wagons = self._create_wagons_from_configs(wagon_configs, train_id, arrival_time)
 
         if not wagons:
-            raise ValueError(f'Train {train_id} must have at least one wagon')
+            # All wagons were filtered out (e.g., already retrofitted or loaded) - nothing to process
+            return
 
         # Create train aggregate
         train = Train(

--- a/popupsim/backend/tests/unit/contexts/retrofit_workflow/application/test_arrival_coordinator.py
+++ b/popupsim/backend/tests/unit/contexts/retrofit_workflow/application/test_arrival_coordinator.py
@@ -206,7 +206,9 @@ class TestArrivalCoordinator:
     def test_empty_wagon_configs(
         self, env: simpy.Environment, coordinator: ArrivalCoordinator, collection_queue: simpy.FilterStore
     ) -> None:
-        """Test train with no wagons raises error."""
-        with pytest.raises(ValueError, match='Train train_1 must have at least one wagon'):
-            coordinator.schedule_train(train_id='train_1', arrival_time=0.0, wagon_configs=[])
-            env.run(until=1.0)
+        """Test train with no eligible wagons is silently skipped."""
+        coordinator.schedule_train(train_id='train_1', arrival_time=0.0, wagon_configs=[])
+        env.run(until=1.0)
+
+        # Train should not be scheduled - nothing to process
+        assert len(coordinator.get_trains()) == 0


### PR DESCRIPTION
## Summary
Up to now an exception was thrown when a train arrives having no wagons for retroffiting. The coordinator throwed an exception. Now instead an early return in the arrival_coordinator is used instead of the raise. The old test checking if the train has wagons to process or if the exception is properly raised is adopted.

## Related Issues/Tickets
None

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test improvement
- [ ] Other (please describe):

## How Has This Been Tested?
The original test which checked the exception is modified to check if the train gets just discarded. No errors were found

## Checklist
- [X] Follows conventional commit message format
- [X] Code is formatted and linted (`uv run ruff format . && uv run ruff check .`)
- [X] All tests pass (`uv run pytest`)
- [X] Documentation updated (if needed)

## Additional Notes

