### PR TITLE
feat(ui): add animated visualization to dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,9 +65,10 @@ htmlcov/
 ehthumbs.db
 Thumbs.db
 
-# Logs
+# Output files
 *.log
 logs/
+output/
 
 # Security
 *.pem

--- a/popupsim/backend/tests/unit/frontend/__init__.py
+++ b/popupsim/backend/tests/unit/frontend/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the Streamlit dashboard frontend components."""

--- a/popupsim/backend/tests/unit/frontend/test_animation_data.py
+++ b/popupsim/backend/tests/unit/frontend/test_animation_data.py
@@ -1,0 +1,697 @@
+"""Unit tests for the animation data transforms (animation_data.py).
+
+These tests use small synthetic event logs mirroring the real
+``resource_locations`` / ``resource_states`` shape. They cover the left-throat
+two-zone layout (with a bottom mainline corridor), the per-frame stack (LIFO)
+compaction, and loco/wagon consist coupling.
+"""
+
+import itertools
+import math
+
+from dashboard_components import animation_data as ad
+from dashboard_components import routes_graph as rg
+import pandas as pd
+import pytest
+
+# --- Fixtures ---------------------------------------------------------------
+
+
+@pytest.fixture
+def tracks_config() -> list[dict]:
+    """Return a minimal tracks config covering several track types."""
+    return [
+        {'id': 'collection1', 'edges': ['collection1'], 'type': 'collection'},
+        {'id': 'retrofit1', 'edges': ['retrofit1'], 'type': 'retrofit'},
+        {'id': 'WS_01', 'edges': ['WS_01'], 'type': 'workshop'},
+        {'id': 'retrofitted1', 'edges': ['retrofitted1'], 'type': 'retrofitted'},
+        {'id': 'Mainline', 'edges': ['Mainline'], 'type': 'mainline'},
+        {'id': 'track_19', 'edges': ['track_19'], 'type': 'rescource_parking'},
+    ]
+
+
+@pytest.fixture
+def topology() -> dict:
+    """Return a matching topology with edge lengths."""
+    return {
+        'nodes': [1, 2],
+        'edges': {
+            'collection1': {'nodes': [1, 2], 'length': 500.0},
+            'retrofit1': {'nodes': [1, 2], 'length': 426.0},
+            'WS_01': {'nodes': [1, 2], 'length': 260.0},
+            'retrofitted1': {'nodes': [1, 2], 'length': 704.0},
+            'Mainline': {'nodes': [1, 2], 'length': 8000.0},
+            'track_19': {'nodes': [1, 2], 'length': 169.0},
+        },
+    }
+
+
+@pytest.fixture
+def workshops_config() -> list[dict]:
+    """Return a workshop config providing bay counts."""
+    return [{'id': 'WS_01', 'name': 'First workshop', 'retrofit_stations': 2, 'track': 'WS1'}]
+
+
+@pytest.fixture
+def layout(tracks_config, topology, workshops_config) -> ad.YardLayout:
+    """Return a built yard layout for the synthetic config (no routes -> single zone)."""
+    return ad.build_layout(tracks_config, topology, workshops_config)
+
+
+@pytest.fixture
+def train_schedule() -> pd.DataFrame:
+    """Return a train schedule with per-wagon real lengths."""
+    return pd.DataFrame(
+        [
+            {'train_id': 'T1', 'wagon_id': 'W0001', 'length': 15.9},
+            {'train_id': 'T1', 'wagon_id': 'W0002', 'length': 23.5},
+        ]
+    )
+
+
+@pytest.fixture
+def w0001_locations() -> pd.DataFrame:
+    """Return a location log mirroring wagon W0001's real trace."""
+    return pd.DataFrame(
+        [
+            {
+                'timestamp': 360.0,
+                'resource_id': 'W0001',
+                'resource_type': 'wagon',
+                'location': 'collection1',
+                'route_path': None,
+            },
+            {
+                'timestamp': 433.0,
+                'resource_id': 'W0001',
+                'resource_type': 'wagon',
+                'location': 'collection1',
+                'route_path': 'collection1|Mainline|retrofit1',
+            },
+            {
+                'timestamp': 493.0,
+                'resource_id': 'W0001',
+                'resource_type': 'wagon',
+                'location': 'retrofit1',
+                'route_path': None,
+            },
+            {
+                'timestamp': 503.0,
+                'resource_id': 'W0001',
+                'resource_type': 'wagon',
+                'location': 'retrofit1',
+                'route_path': 'retrofit1|WS_01',
+            },
+            {
+                'timestamp': 508.0,
+                'resource_id': 'W0001',
+                'resource_type': 'wagon',
+                'location': 'WS_01',
+                'route_path': None,
+            },
+        ]
+    )
+
+
+@pytest.fixture
+def w0001_states() -> pd.DataFrame:
+    """Return a state log marking the retrofit-completion timestamp."""
+    return pd.DataFrame(
+        [
+            {'timestamp': 360.0, 'resource_id': 'W0001', 'resource_type': 'wagon', 'state': 'arrived'},
+            {'timestamp': 433.0, 'resource_id': 'W0001', 'resource_type': 'wagon', 'state': 'moving'},
+            {'timestamp': 493.0, 'resource_id': 'W0001', 'resource_type': 'wagon', 'state': 'queued'},
+            {'timestamp': 508.0, 'resource_id': 'W0001', 'resource_type': 'wagon', 'state': 'in_workshop'},
+            {'timestamp': 574.0, 'resource_id': 'W0001', 'resource_type': 'wagon', 'state': 'retrofitted'},
+        ]
+    )
+
+
+@pytest.fixture
+def loco_locations() -> pd.DataFrame:
+    """Return a locomotive location log (uses previous_location, no route_path)."""
+    return pd.DataFrame(
+        [
+            {
+                'timestamp': 360.0,
+                'resource_id': 'LOCO_01',
+                'resource_type': 'locomotive',
+                'location': 'track_19',
+                'previous_location': None,
+                'route_path': None,
+            },
+            {
+                'timestamp': 420.0,
+                'resource_id': 'LOCO_01',
+                'resource_type': 'locomotive',
+                'location': 'collection1',
+                'previous_location': 'track_19',
+                'route_path': None,
+            },
+            {
+                'timestamp': 500.0,
+                'resource_id': 'LOCO_01',
+                'resource_type': 'locomotive',
+                'location': 'retrofit1',
+                'previous_location': 'collection1',
+                'route_path': None,
+            },
+        ]
+    )
+
+
+def _track_layout(track_type: str, length: float, bays: int | None = None) -> ad.TrackLayout:
+    """Build a single left-throat TrackLayout (throat at x=0, extends right)."""
+    return ad.TrackLayout(
+        track_id='T',
+        track_type=track_type,
+        lane_y=0.0,
+        x_start=0.0,
+        x_end=length,
+        length_m=length,
+        color='#000000',
+        is_workshop=track_type == 'workshop',
+        bays=bays,
+        throat_x=0.0,
+        zone='local',
+    )
+
+
+def _one_track_layout(track_type: str, length: float, bays: int | None = None) -> ad.YardLayout:
+    """Build a single-track yard layout for compaction tests."""
+    return ad.YardLayout(
+        tracks={'T': _track_layout(track_type, length, bays)},
+        throat_x=0.0,
+        x_max=length,
+        y_min=0.0,
+        y_max=0.0,
+        mode='single',
+        left_throat_x=0.0,
+    )
+
+
+def _wagons(track: str, specs: list[tuple[str, float, float, float]]) -> dict[str, ad.ResourceTrack]:
+    """Build wagons on ``track`` from (id, length, t_arrive, t_depart) specs."""
+    timelines: dict[str, ad.ResourceTrack] = {}
+    for rid, length, t_arrive, t_depart in specs:
+        rt = ad.ResourceTrack(rid, 'wagon', length_m=length, dwells=[ad.Dwell(track, t_arrive, t_depart)])
+        rt.first_seen = t_arrive
+        timelines[rid] = rt
+    return timelines
+
+
+def _intervals(
+    layout: ad.YardLayout, timelines: dict[str, ad.ResourceTrack], track: str, t: float
+) -> list[tuple[float, float]]:
+    """Return sorted (start, end) x-extents of resources packed on ``track`` at ``t``."""
+    centers = ad._packed_centers(layout, timelines, track, t)
+    spans = [(cx - timelines[rid].length_m / 2.0, cx + timelines[rid].length_m / 2.0) for rid, cx in centers.items()]
+    return sorted(spans)
+
+
+def _has_overlap(intervals: list[tuple[float, float]]) -> bool:
+    """Return True if any two sorted intervals overlap by more than a rounding epsilon."""
+    return any(a[1] - b[0] > 1e-6 for a, b in itertools.pairwise(intervals))
+
+
+# --- Segment extraction -----------------------------------------------------
+
+
+class TestExtractTimelines:
+    """Tests for movement-segment extraction."""
+
+    def test_wagon_segments_follow_route_path(self, w0001_locations, w0001_states):
+        """Wagon dwells/moves should follow the recorded location sequence."""
+        timelines = ad.extract_timelines(w0001_locations, w0001_states)
+        rt = timelines['W0001']
+        assert rt.resource_type == 'wagon'
+        assert [d.track for d in rt.dwells] == ['collection1', 'retrofit1', 'WS_01']
+        assert len(rt.moves) == 2
+
+    def test_wagon_departure_uses_moving_event(self, w0001_locations, w0001_states):
+        """The move should start at the route_path/moving row and end at arrival."""
+        rt = ad.extract_timelines(w0001_locations, w0001_states)['W0001']
+        first_move = rt.moves[0]
+        assert first_move.t_depart == 433.0
+        assert first_move.t_arrive == 493.0
+        assert first_move.route == ('collection1', 'Mainline', 'retrofit1')
+
+    def test_retrofit_timestamp_detected(self, w0001_locations, w0001_states):
+        """The retrofit-completion timestamp should be captured for colouring."""
+        rt = ad.extract_timelines(w0001_locations, w0001_states)['W0001']
+        assert rt.t_retrofitted == 574.0
+
+    def test_locomotive_uses_default_transit_and_length(self, loco_locations):
+        """Locomotives use the default transit fallback and default length."""
+        rt = ad.extract_timelines(loco_locations, None)['LOCO_01']
+        assert rt.resource_type == 'locomotive'
+        assert rt.length_m == ad.LOCO_LENGTH_M
+        assert rt.moves[0].t_depart == pytest.approx(420.0 - ad.DEFAULT_TRANSIT_MIN)
+
+    def test_wagon_length_from_schedule(self, w0001_locations, w0001_states, train_schedule):
+        """Wagon length should be taken from the train schedule when provided."""
+        lengths = ad.wagon_lengths(train_schedule)
+        rt = ad.extract_timelines(w0001_locations, w0001_states, lengths)['W0001']
+        assert rt.length_m == pytest.approx(15.9)
+
+    def test_empty_input_returns_empty(self):
+        """Empty or missing location logs should yield no timelines."""
+        assert ad.extract_timelines(None, None) == {}
+        assert ad.extract_timelines(pd.DataFrame(), None) == {}
+
+
+class TestWagonLengths:
+    """Tests for the wagon-length lookup helper."""
+
+    def test_maps_ids_to_lengths(self, train_schedule):
+        """Each wagon id should map to its float length."""
+        lengths = ad.wagon_lengths(train_schedule)
+        assert lengths == {'W0001': pytest.approx(15.9), 'W0002': pytest.approx(23.5)}
+
+    def test_missing_columns_returns_empty(self):
+        """A schedule without the expected columns yields an empty map."""
+        assert ad.wagon_lengths(pd.DataFrame([{'foo': 1}])) == {}
+        assert ad.wagon_lengths(None) == {}
+
+
+# --- Yard layout ------------------------------------------------------------
+
+
+class TestBuildLayout:
+    """Tests for the left-throat synthetic yard layout."""
+
+    def test_tracks_are_left_throat(self, layout):
+        """Every non-mainline track's throat is on its left edge and extends right."""
+        for tl in layout.tracks.values():
+            if tl.zone == 'mainline':
+                continue
+            assert tl.throat_x == pytest.approx(tl.x_start)
+            assert tl.x_end > tl.x_start
+
+    def test_mainline_is_bottom_corridor(self, layout):
+        """The mainline sits at the top lane in single-column mode."""
+        main = layout.tracks['Mainline']
+        assert main.zone == 'single'
+        assert main.lane_y == max(t.lane_y for t in layout.tracks.values())
+
+    def test_workshop_tagged_with_bays(self, layout):
+        """Workshop tracks should be tagged and carry their bay count."""
+        ws = layout.tracks['WS_01']
+        assert ws.is_workshop is True
+        assert ws.bays == 2
+
+    def test_x_axis_is_metric(self, layout):
+        """Non-mainline tracks span their real length in metres from the throat."""
+        assert layout.tracks['collection1'].x_end - layout.tracks['collection1'].x_start == pytest.approx(500.0)
+        assert layout.tracks['retrofitted1'].x_end - layout.tracks['retrofitted1'].x_start == pytest.approx(704.0)
+
+    def test_single_mode_without_remote(self, layout):
+        """Without a remote cluster the layout uses the single-column mode."""
+        assert layout.mode == 'single'
+
+
+# --- Stack (LIFO) compaction ------------------------------------------------
+
+
+class TestCompaction:
+    """Tests for the per-frame, hole-free stack compaction."""
+
+    def test_stack_packs_earliest_deepest(self):
+        """Earliest arrival sits at the far (right) end; later arrivals toward the throat."""
+        layout = _one_track_layout('collection', 100.0)
+        timelines = _wagons('T', [('A', 16.0, 0.0, 200.0), ('B', 16.0, 10.0, 200.0)])
+        centers = ad._packed_centers(layout, timelines, 'T', 100.0)
+        assert centers['A'] == pytest.approx(92.0)  # 100 - 16/2, flush against far end
+        assert centers['B'] < centers['A']
+
+    def test_no_gap_between_adjacent(self):
+        """Adjacent packed wagons sit flush (no hole)."""
+        layout = _one_track_layout('collection', 100.0)
+        timelines = _wagons('T', [('A', 16.0, 0.0, 200.0), ('B', 24.0, 10.0, 200.0)])
+        a, b = (
+            ad._packed_centers(layout, timelines, 'T', 100.0)['A'],
+            ad._packed_centers(layout, timelines, 'T', 100.0)['B'],
+        )
+        a_near = a - 16.0 / 2  # throat-side edge of A
+        b_far = b + 24.0 / 2  # far-side edge of B
+        assert a_near - b_far == pytest.approx(ad.UNIFORM_GAP_M)
+
+    def test_departure_makes_others_slide(self):
+        """When a wagon departs, the remaining present wagons re-pack flush (no hole)."""
+        layout = _one_track_layout('collection', 100.0)
+        timelines = _wagons('T', [('A', 16.0, 0.0, 50.0), ('B', 16.0, 0.0, 200.0)])
+        # While both present, B is left of A; after A leaves, B slides to the far end.
+        assert ad._packed_centers(layout, timelines, 'T', 10.0)['B'] < 92.0
+        assert ad._packed_centers(layout, timelines, 'T', 60.0)['B'] == pytest.approx(92.0)
+
+    def test_locomotive_sits_on_throat_side(self):
+        """A locomotive parked with wagons sits on the throat (left) side of them."""
+        layout = _one_track_layout('collection', 100.0)
+        timelines = _wagons('T', [('W', 16.0, 0.0, 200.0)])
+        loco = ad.ResourceTrack('L', 'locomotive', length_m=19.0, dwells=[ad.Dwell('T', 10.0, 200.0)])
+        loco.first_seen = 10.0
+        timelines['L'] = loco
+        centers = ad._packed_centers(layout, timelines, 'T', 100.0)
+        assert centers['L'] < centers['W']
+
+    def test_workshop_uses_bay_slots(self):
+        """Workshop occupants take distinct bay-slot centres inside the box."""
+        layout = _one_track_layout('workshop', 260.0, bays=2)
+        timelines = _wagons('T', [('A', 16.0, 0.0, 200.0), ('B', 16.0, 10.0, 200.0)])
+        centers = sorted(ad._packed_centers(layout, timelines, 'T', 100.0).values())
+        assert centers == pytest.approx([260.0 * 0.25, 260.0 * 0.75])
+
+    def test_no_overlap_when_wagons_fit(self):
+        """Wagons whose true lengths fit must never overlap."""
+        layout = _one_track_layout('collection', 100.0)
+        timelines = _wagons('T', [(f'W{i}', 10.0, float(i), 200.0) for i in range(7)])
+        assert not _has_overlap(_intervals(layout, timelines, 'T', 150.0))
+
+    def test_overflow_positions_are_distinct(self):
+        """Over-capacity wagons pack sequentially (distinct centres), never stacked."""
+        layout = _one_track_layout('collection', 10.0)
+        timelines = _wagons('T', [(f'W{i}', 1.0, float(i), 200.0) for i in range(15)])
+        centres = list(ad._packed_centers(layout, timelines, 'T', 150.0).values())
+        assert len({round(c, 6) for c in centres}) == len(centres)
+
+    def test_workshop_overflow_stays_within_box(self):
+        """More wagons than bays must still render inside the workshop box."""
+        layout = _one_track_layout('workshop', 260.0, bays=2)
+        timelines = _wagons('T', [(f'W{i}', 16.0, float(i), 200.0) for i in range(3)])
+        tl = layout.tracks['T']
+        for rid, center in ad._packed_centers(layout, timelines, 'T', 150.0).items():
+            half = timelines[rid].length_m / 2.0
+            assert center - half >= tl.x_start - 1e-6
+            assert center + half <= tl.x_end + 1e-6
+
+
+# --- Consist coupling -------------------------------------------------------
+
+
+class TestConsists:
+    """Tests for loco/wagon consist inference and synchronised motion."""
+
+    @staticmethod
+    def _coupled() -> dict[str, ad.ResourceTrack]:
+        """Build a loco and two wagons making the same collection1->retrofit1 trip."""
+        wagons = {}
+        for rid, t_arr in (('W1', 0.0), ('W2', 5.0)):
+            rt = ad.ResourceTrack(rid, 'wagon', length_m=16.0)
+            rt.dwells = [ad.Dwell('collection1', t_arr, 100.0), ad.Dwell('retrofit1', 200.0, math.inf)]
+            rt.moves = [ad.Move(100.0, 200.0, ('collection1', 'Mainline', 'retrofit1'), 'collection1', 'retrofit1')]
+            rt.first_seen = t_arr
+            wagons[rid] = rt
+        loco = ad.ResourceTrack('L', 'locomotive', length_m=19.0)
+        loco.dwells = [ad.Dwell('collection1', 90.0, 95.0), ad.Dwell('retrofit1', 130.0, math.inf)]
+        loco.moves = [ad.Move(95.0, 130.0, (), 'collection1', 'retrofit1')]
+        loco.first_seen = 90.0
+        return {**wagons, 'L': loco}
+
+    def test_loco_move_snaps_to_rake_window(self):
+        """The loco's hauling move is snapped to the rake's depart/arrive window."""
+        timelines = self._coupled()
+        legs = ad.infer_consists(timelines)
+        assert 'L' in legs
+        leg = legs['L'][0]
+        assert (leg.t_depart, leg.t_arrive) == (100.0, 200.0)
+        assert timelines['L'].moves[0].t_depart == 100.0
+        assert timelines['L'].moves[0].t_arrive == 200.0
+
+    def test_consist_includes_loco_and_wagons(self):
+        """The leg lists the loco first, then its wagons."""
+        leg = ad.infer_consists(self._coupled())['L'][0]
+        assert leg.car_ids[0] == 'L'
+        assert set(leg.car_ids[1:]) == {'W1', 'W2'}
+
+    def test_loco_leads_throat_side_during_transit(self, tracks_config, topology, workshops_config):
+        """Mid-transit the loco stays on the throat side and cars do not overlap."""
+        graph = rg.parse_routes(
+            {'routes': [{'id': 'r', 'duration': 5.0, 'path': ['collection1', 'Mainline', 'retrofit1']}]}
+        )
+        layout = ad.build_layout(tracks_config, topology, workshops_config, graph, sorted(graph.track_ids))
+        timelines = self._coupled()
+        legs = ad.assign_positions(layout, timelines)
+        # At arrival the loco sits on the throat side (smaller x) of both wagons.
+        loco_x = ad.position_at(timelines['L'], layout, timelines, 200.0, legs)[0]
+        w1_x = ad.position_at(timelines['W1'], layout, timelines, 200.0, legs)[0]
+        w2_x = ad.position_at(timelines['W2'], layout, timelines, 200.0, legs)[0]
+        assert loco_x < w1_x
+        assert loco_x < w2_x
+        assert abs(w1_x - w2_x) > 1e-6  # the two wagons do not coincide
+
+    def test_unmatched_loco_trip_left_alone(self):
+        """A loco trip with no matching wagons produces no leg."""
+        loco = ad.ResourceTrack('L', 'locomotive', length_m=19.0)
+        loco.dwells = [ad.Dwell('track_19', 0.0, 10.0), ad.Dwell('collection1', 22.0, math.inf)]
+        loco.moves = [ad.Move(10.0, 22.0, (), 'track_19', 'collection1')]
+        loco.first_seen = 0.0
+        assert ad.infer_consists({'L': loco}) == {}
+
+
+# --- Frame stats ------------------------------------------------------------
+
+
+class TestFrameStats:
+    """Tests for the per-frame live statistics."""
+
+    @staticmethod
+    def _timelines() -> dict[str, ad.ResourceTrack]:
+        """Two wagons on one track; W1 retrofitted at t=50, W2 never."""
+        w1 = ad.ResourceTrack('W1', 'wagon', length_m=20.0, dwells=[ad.Dwell('T', 0.0, math.inf)])
+        w1.first_seen, w1.t_retrofitted = 0.0, 50.0
+        w2 = ad.ResourceTrack('W2', 'wagon', length_m=30.0, dwells=[ad.Dwell('T', 10.0, math.inf)])
+        w2.first_seen = 10.0
+        return {'W1': w1, 'W2': w2}
+
+    def test_counts_before_and_after_retrofit(self):
+        """to_retrofit / retrofitted counts reflect presence and completion."""
+        layout = _one_track_layout('collection', 100.0)
+        timelines = self._timelines()
+        early = ad._frame_stats(layout, timelines, 5.0, [])
+        assert (early.to_retrofit, early.present_retrofitted, early.cumulative_retrofitted) == (1, 0, 0)
+        late = ad._frame_stats(layout, timelines, 60.0, [])
+        assert (late.to_retrofit, late.present_retrofitted, late.cumulative_retrofitted) == (1, 1, 1)
+
+    def test_track_utilization_is_occupied_over_real_length(self):
+        """Utilization sums real wagon lengths over the real track length."""
+        layout = _one_track_layout('collection', 100.0)
+        stats = ad._frame_stats(layout, self._timelines(), 60.0, [])
+        assert stats.utilization['T'] == pytest.approx(0.5)  # (20 + 30) / 100
+
+    def test_cumulative_rejected_is_monotonic(self):
+        """Rejected counter accumulates as timestamps are passed."""
+        layout = _one_track_layout('collection', 100.0)
+        timelines = self._timelines()
+        rejected = [40.0, 70.0]
+        assert ad._frame_stats(layout, timelines, 5.0, rejected).cumulative_rejected == 0
+        assert ad._frame_stats(layout, timelines, 60.0, rejected).cumulative_rejected == 1
+        assert ad._frame_stats(layout, timelines, 100.0, rejected).cumulative_rejected == 2
+
+    def test_mainline_excluded_from_utilization(self, layout):
+        """The Mainline is excluded from per-track utilization."""
+        stats = ad._frame_stats(layout, self._timelines(), 60.0, [])
+        assert 'Mainline' not in stats.utilization
+
+    def test_build_frames_attaches_stats_and_shades(self):
+        """build_frames wires stats and alternating shades into every frame."""
+        layout = _one_track_layout('collection', 100.0)
+        frames = ad.build_frames(layout, self._timelines(), num_frames=5, rejected_at=[40.0])
+        assert all(isinstance(f.stats, ad.FrameStats) for f in frames)
+        last = frames[-1]
+        assert len(last.wagon_shade) == len(last.wagon_x)
+        if len(last.wagon_shade) == 2:
+            assert set(last.wagon_shade) == {0, 1}
+
+
+# --- Position resolver ------------------------------------------------------
+
+
+class TestPositionAt:
+    """Tests for the position resolver."""
+
+    def test_parked_uses_compacted_slot(self, layout, w0001_locations, w0001_states):
+        """At a dwell the wagon sits at its compacted slot on the track lane."""
+        timelines = ad.extract_timelines(w0001_locations, w0001_states)
+        legs = ad.assign_positions(layout, timelines)
+        rt = timelines['W0001']
+        expected_x = ad._packed_centers(layout, timelines, 'collection1', 360.0)['W0001']
+        pos = ad.position_at(rt, layout, timelines, 360.0, legs)
+        assert pos == pytest.approx((expected_x, layout.tracks['collection1'].lane_y))
+
+    def test_move_routes_through_throat(self, layout, w0001_locations, w0001_states):
+        """An intra-zone move routes through the throat (x == throat_x)."""
+        timelines = ad.extract_timelines(w0001_locations, w0001_states)
+        ad.assign_positions(layout, timelines)
+        waypoints = ad._move_waypoints(layout, timelines['W0001'].moves[0])
+        assert any(abs(p[0] - layout.throat_x) < 1e-9 for p in waypoints)
+
+    def test_none_before_first_seen(self, layout, w0001_locations, w0001_states):
+        """A resource has no position before it first appears."""
+        timelines = ad.extract_timelines(w0001_locations, w0001_states)
+        legs = ad.assign_positions(layout, timelines)
+        assert ad.position_at(timelines['W0001'], layout, timelines, 100.0, legs) is None
+
+
+# --- Frame builder ----------------------------------------------------------
+
+
+class TestBuildFrames:
+    """Tests for the per-frame builder."""
+
+    def test_frame_count_matches_resolution(self, layout, w0001_locations, w0001_states):
+        """The number of frames equals the requested resolution."""
+        timelines = ad.extract_timelines(w0001_locations, w0001_states)
+        assert len(ad.build_frames(layout, timelines, num_frames=50)) == 50
+
+    def test_first_frame_carries_position_and_length(self, layout, w0001_locations, w0001_states, train_schedule):
+        """The first frame places the wagon at its compacted slot and carries its length."""
+        lengths = ad.wagon_lengths(train_schedule)
+        timelines = ad.extract_timelines(w0001_locations, w0001_states, lengths)
+        frames = ad.build_frames(layout, timelines, num_frames=10)
+        first = frames[0]
+        assert first.t == pytest.approx(360.0)
+        assert first.wagon_ids == ['W0001']
+        assert first.wagon_len[0] == pytest.approx(15.9)
+        expected_x = ad._packed_centers(layout, timelines, 'collection1', 360.0)['W0001']
+        assert first.wagon_x[0] == pytest.approx(expected_x)
+
+    def test_color_flips_at_retrofit_time(self, layout, w0001_locations, w0001_states):
+        """Wagon colour switches from blue to green at the retrofit timestamp."""
+        timelines = ad.extract_timelines(w0001_locations, w0001_states)
+        frames = ad.build_frames(layout, timelines, num_frames=3, bounds=(560.0, 580.0))
+        assert frames[0].wagon_color[0] == ad.WAGON_COLOR_PENDING
+        assert frames[-1].wagon_color[0] == ad.WAGON_COLOR_DONE
+
+    def test_locomotives_separated_from_wagons(self, layout, w0001_locations, loco_locations):
+        """Locomotives appear only in the locomotive arrays, never the wagon arrays."""
+        combined = pd.concat([w0001_locations, loco_locations], ignore_index=True)
+        timelines = ad.extract_timelines(combined, None)
+        frames = ad.build_frames(layout, timelines, num_frames=5)
+        assert any('LOCO_01' in f.loco_ids for f in frames)
+        assert all('LOCO_01' not in f.wagon_ids for f in frames)
+        assert all(length == ad.LOCO_LENGTH_M for f in frames for length in f.loco_len)
+
+    def test_empty_timelines_returns_empty(self, layout):
+        """No timelines yields no frames."""
+        assert ad.build_frames(layout, {}, num_frames=10) == []
+
+    def test_sim_time_bounds(self, w0001_locations, loco_locations):
+        """Simulation bounds span the earliest and latest resource timestamps."""
+        combined = pd.concat([w0001_locations, loco_locations], ignore_index=True)
+        timelines = ad.extract_timelines(combined, None)
+        assert ad.sim_time_bounds(timelines) == (360.0, 508.0)
+
+    def test_single_frame_does_not_divide_by_zero(self, layout, w0001_locations, w0001_states):
+        """A single-frame request produces one finite-time frame."""
+        timelines = ad.extract_timelines(w0001_locations, w0001_states)
+        frames = ad.build_frames(layout, timelines, num_frames=1)
+        assert len(frames) == 1
+        assert math.isfinite(frames[0].t)
+
+
+# --- Routes-aware layout ----------------------------------------------------
+
+
+class TestRoutesAwareLayout:
+    """Tests for routes-aware, id-robust layout building."""
+
+    @staticmethod
+    def _h4r_config() -> tuple[list[dict], dict, list[dict], dict]:
+        """Return hack4rail-style config with a workshop id mismatch (WS1 vs WS_01)."""
+        tracks = [
+            {'id': 'WS1', 'edges': ['WS1'], 'type': 'workshop'},
+            {'id': 'collection1', 'edges': ['collection1'], 'type': 'collection'},
+            {'id': 'track_19', 'edges': ['track_19'], 'type': 'rescource_parking'},
+            {'id': 'Mainline', 'edges': ['Mainline'], 'type': 'mainline'},
+            {'id': 'retrofit', 'edges': ['retrofit'], 'type': 'retrofit'},
+        ]
+        topology = {
+            'edges': {
+                'WS1': {'length': 260.0},
+                'collection1': {'length': 740.0},
+                'track_19': {'length': 169.0},
+                'Mainline': {'length': 8000.0},
+                'retrofit': {'length': 740.0},
+            }
+        }
+        workshops = [{'id': 'WS_01', 'retrofit_stations': 2, 'track': 'track_WS1'}]
+        routes = {
+            'routes': [
+                {'id': 'a', 'duration': 5.0, 'path': ['track_19', 'WS_01']},
+                {'id': 'b', 'duration': 5.0, 'path': ['track_19', 'retrofit']},
+                {'id': 'c', 'duration': 60.0, 'path': ['track_19', 'Mainline', 'collection1']},
+            ]
+        }
+        return tracks, topology, workshops, routes
+
+    def test_workshop_id_mismatch_resolved(self):
+        """A workshop id (WS_01) absent from tracks.json still gets a lane with bays."""
+        tracks, topology, workshops, routes = self._h4r_config()
+        graph = rg.parse_routes(routes)
+        layout = ad.build_layout(tracks, topology, workshops, graph, sorted(graph.track_ids))
+        ws = layout.tracks['WS_01']
+        assert ws.is_workshop is True
+        assert ws.bays == 2
+        assert ws.length_m == pytest.approx(260.0)
+
+    def test_two_zone_placement(self):
+        """With a remote cluster the layout uses three zones (left | corridor | right)."""
+        tracks, topology, workshops, routes = self._h4r_config()
+        graph = rg.parse_routes(routes)
+        layout = ad.build_layout(tracks, topology, workshops, graph, sorted(graph.track_ids))
+        assert layout.mode == 'zones'
+        assert layout.tracks['retrofit'].zone == 'left'
+        assert layout.tracks['collection1'].zone == 'right'
+        assert layout.tracks['Mainline'].zone == 'middle'
+        # Local yard left of left ladder, remote right of right ladder.
+        assert layout.tracks['retrofit'].x_end <= layout.left_throat_x + 1e-9
+        assert layout.tracks['collection1'].x_start >= layout.right_throat_x - 1e-9
+        assert layout.left_throat_x < layout.right_throat_x < layout.x_max
+
+    def test_mainline_corridor_in_the_middle(self):
+        """The mainline corridor spans between the two ladders at corridor_y."""
+        tracks, topology, workshops, routes = self._h4r_config()
+        graph = rg.parse_routes(routes)
+        layout = ad.build_layout(tracks, topology, workshops, graph, sorted(graph.track_ids))
+        main = layout.tracks['Mainline']
+        assert main.lane_y == pytest.approx(layout.corridor_y)
+        assert main.x_start == pytest.approx(layout.left_throat_x)
+        assert main.x_end == pytest.approx(layout.right_throat_x)
+
+    def test_cross_zone_move_passes_through_corridor(self):
+        """A local<->remote move routes through the Mainline corridor height."""
+        tracks, topology, workshops, routes = self._h4r_config()
+        graph = rg.parse_routes(routes)
+        layout = ad.build_layout(tracks, topology, workshops, graph, sorted(graph.track_ids))
+        rt = ad.ResourceTrack('W', 'wagon', length_m=16.0)
+        rt.dwells = [ad.Dwell('collection1', 0.0, 100.0), ad.Dwell('retrofit', 200.0, math.inf)]
+        rt.moves = [ad.Move(100.0, 200.0, ('collection1', 'Mainline', 'retrofit'), 'collection1', 'retrofit')]
+        rt.first_seen = 0.0
+        ad.assign_positions(layout, {'W': rt})
+        waypoints = ad._move_waypoints(layout, rt.moves[0])
+        corridor_pts = [p for p in waypoints if abs(p[1] - layout.corridor_y) < 1e-9]
+        assert any(abs(p[0] - layout.left_throat_x) < 1e-9 for p in corridor_pts)
+        assert any(abs(p[0] - layout.right_throat_x) < 1e-9 for p in corridor_pts)
+
+    def test_layout_without_routes_is_single_mode(self):
+        """Without a route graph the layout falls back to a single stacked column."""
+        tracks, topology, workshops, _routes = self._h4r_config()
+        layout = ad.build_layout(tracks, topology, workshops)
+        assert layout.mode == 'single'
+        assert set(layout.tracks) == {'WS1', 'collection1', 'track_19', 'Mainline', 'retrofit'}
+        assert layout.tracks['Mainline'].lane_y == max(t.lane_y for t in layout.tracks.values())
+
+
+class TestActiveTrackIds:
+    """Tests for the active-id collector."""
+
+    def test_union_of_routes_and_locations(self):
+        """Active ids combine route track ids and event-log locations."""
+        graph = rg.parse_routes({'routes': [{'id': 'a', 'duration': 5.0, 'path': ['track_19', 'WS_01']}]})
+        locs = pd.DataFrame([{'location': 'collection1'}, {'location': 'WS_01'}, {'location': None}])
+        ids = ad.active_track_ids(locs, graph)
+        assert set(ids) == {'track_19', 'WS_01', 'collection1'}
+
+    def test_handles_missing_inputs(self):
+        """Missing locations / graph degrade gracefully."""
+        assert ad.active_track_ids(None, None) == []

--- a/popupsim/backend/tests/unit/frontend/test_animation_data.py
+++ b/popupsim/backend/tests/unit/frontend/test_animation_data.py
@@ -432,9 +432,15 @@ class TestConsists:
         timelines = self._coupled()
         legs = ad.assign_positions(layout, timelines)
         # At arrival the loco sits on the throat side (smaller x) of both wagons.
-        loco_x = ad.position_at(timelines['L'], layout, timelines, 200.0, legs)[0]
-        w1_x = ad.position_at(timelines['W1'], layout, timelines, 200.0, legs)[0]
-        w2_x = ad.position_at(timelines['W2'], layout, timelines, 200.0, legs)[0]
+        loco_pos = ad.position_at(timelines['L'], layout, timelines, 200.0, legs)
+        w1_pos = ad.position_at(timelines['W1'], layout, timelines, 200.0, legs)
+        w2_pos = ad.position_at(timelines['W2'], layout, timelines, 200.0, legs)
+        assert loco_pos is not None
+        assert w1_pos is not None
+        assert w2_pos is not None
+        loco_x = loco_pos[0]
+        w1_x = w1_pos[0]
+        w2_x = w2_pos[0]
         assert loco_x < w1_x
         assert loco_x < w2_x
         assert abs(w1_x - w2_x) > 1e-6  # the two wagons do not coincide

--- a/popupsim/backend/tests/unit/frontend/test_routes_graph.py
+++ b/popupsim/backend/tests/unit/frontend/test_routes_graph.py
@@ -1,0 +1,79 @@
+"""Unit tests for routes.json parsing and clustering (routes_graph.py)."""
+
+from dashboard_components import routes_graph as rg
+import pytest
+
+
+@pytest.fixture
+def routes_json() -> dict:
+    """Return a routes payload mirroring the hack4rail connectivity shape."""
+    return {
+        'routes': [
+            {'id': 'track_19_collection1', 'duration': 60.0, 'path': ['track_19', 'Mainline', 'collection1']},
+            {'id': 'collection1_retrofit', 'duration': 60.0, 'path': ['collection1', 'Mainline', 'retrofit']},
+            {'id': 'track_19_retrofit', 'duration': 5.0, 'path': ['track_19', 'retrofit']},
+            {'id': 'track_19_WS_01', 'duration': 5.0, 'path': ['track_19', 'WS_01']},
+            {'id': 'retrofit_WS_01', 'duration': 5.0, 'path': ['retrofit', 'WS_01']},
+            {'id': 'WS_01_retrofitted', 'duration': 5.0, 'path': ['WS_01', 'retrofitted']},
+            {'id': 'retrofitted_parking1', 'duration': 30.0, 'path': ['retrofitted', 'parking1']},
+            {'id': 'retrofitted_parking6', 'duration': 30.0, 'path': ['retrofitted', 'Mainline', 'parking6']},
+        ]
+    }
+
+
+class TestParseRoutes:
+    """Tests for parse_routes."""
+
+    def test_empty_input_yields_empty_graph(self):
+        """No routes yields an empty, all-local graph."""
+        graph = rg.parse_routes(None)
+        assert graph.track_ids == frozenset()
+        assert graph.adjacency == {}
+
+    def test_track_ids_collected(self, routes_json):
+        """Every track referenced in any path is collected."""
+        graph = rg.parse_routes(routes_json)
+        assert 'WS_01' in graph.track_ids
+        assert 'collection1' in graph.track_ids
+        assert 'Mainline' in graph.track_ids
+
+    def test_adjacency_is_undirected_with_min_duration(self, routes_json):
+        """Adjacency is symmetric and keeps the minimum duration."""
+        graph = rg.parse_routes(routes_json)
+        assert graph.adjacency['track_19']['retrofit'] == 5.0
+        assert graph.adjacency['retrofit']['track_19'] == 5.0
+
+    def test_direct_excludes_mainline_hops(self, routes_json):
+        """Direct neighbours only include non-Mainline hops."""
+        graph = rg.parse_routes(routes_json)
+        assert 'retrofit' in graph.direct['track_19']  # direct 5-min hop
+        assert 'collection1' not in graph.direct.get('track_19', {})  # only via Mainline
+
+    def test_paths_recorded(self, routes_json):
+        """Endpoint pairs map to their full ordered path."""
+        graph = rg.parse_routes(routes_json)
+        assert graph.paths[('track_19', 'collection1')] == ('track_19', 'Mainline', 'collection1')
+
+
+class TestClusters:
+    """Tests for cluster classification."""
+
+    def test_hub_and_local_and_remote(self, routes_json):
+        """track_19 is the hub; locally-reachable tracks are local; rest remote."""
+        graph = rg.parse_routes(routes_json)
+        assert graph.cluster['track_19'] == 'hub'
+        assert graph.cluster['retrofit'] == 'local'
+        assert graph.cluster['WS_01'] == 'local'
+        assert graph.cluster['retrofitted'] == 'local'
+        assert graph.cluster['parking1'] == 'local'  # directly off retrofitted
+        assert graph.cluster['Mainline'] == 'mainline'
+
+    def test_collection_and_far_parking_are_remote(self, routes_json):
+        """Tracks only reachable across the Mainline are remote."""
+        graph = rg.parse_routes(routes_json)
+        assert graph.cluster['collection1'] == 'remote'
+        assert graph.cluster['parking6'] == 'remote'
+
+    def test_cluster_rank_orders_remote_above_local(self):
+        """Cluster ranks place remote on top and local below the Mainline."""
+        assert rg.CLUSTER_RANK['remote'] < rg.CLUSTER_RANK['mainline'] < rg.CLUSTER_RANK['local']

--- a/popupsim/frontend/README.md
+++ b/popupsim/frontend/README.md
@@ -35,6 +35,33 @@ Timeline-based bottleneck identification:
 - Locomotive usage
 - Interactive timeline visualization
 
+### 4. Animation Tab 🎬
+
+Animated playback of a simulation run on a schematic yard:
+
+- Wagons and locomotives move along their recorded routes over time
+- Wagons are **blue** until retrofitted, then turn **green** (color-blind-safe Okabe-Ito palette);
+  locomotives are distinct dark squares
+- **Coupled consists**: locomotives are matched to the wagons they haul and the consist travels as
+  one rigid, spaced train, with the locomotive always on the throat side (so it pulls on the way
+  out and pushes on the way in, never overlapping its wagons)
+- Three-zone layout (local yard · Mainline corridor · remote storage) when routes span the Mainline
+- Wagons pack flush to the far end (away from the throat) as a **stack (LIFO)**, re-compacted every
+  frame so there are never holes (a departing wagon makes the rest slide); adjacent wagons alternate
+  fill shade plus a border so they stay countable
+- Workshops drawn as labeled buildings showing their bay count; wagons always render inside the box
+- **Live statistics** that update as the clock advances (above the layout):
+  - wagons still to retrofit currently in the system
+  - wagons retrofitted currently in the system, and the cumulative retrofitted total
+  - cumulative rejected wagons
+  - per-track capacity usage (Σ real wagon lengths ÷ real track length, Mainline excluded)
+- Native Plotly play/pause + time slider (client-side, smooth scrubbing), with **⏮ / ⏭ buttons**
+  underneath that step a single frame at a time — fully in-browser, staying in sync with play and
+  the slider (the figure is embedded as HTML and loads Plotly from a CDN, so first paint needs
+  internet)
+- User-selectable resolution on a quadratic scale (**200 up to 10,000 frames**), animation length,
+  and playback speed
+
 ## Running the Dashboard
 
 ### Option 1: Batch File (Windows)

--- a/popupsim/frontend/dashboard.py
+++ b/popupsim/frontend/dashboard.py
@@ -56,7 +56,7 @@ def main() -> None:
     base_path = Path(base_dir)
 
     if not base_path.exists():
-        st.error(f'❌ Base directory not found: {base_dir}'/home/felix/git/duplicate/team-max/scenario-h4r-2-track-fix-base)
+        st.error(f'❌ Base directory not found: {base_dir}')
         st.stop()
 
     # Scan for scenario folders (folders containing a 'scenario' subdirectory)

--- a/popupsim/frontend/dashboard.py
+++ b/popupsim/frontend/dashboard.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+from dashboard_components.animation_tab import render_animation_tab
 from dashboard_components.bottleneck_tab import render_bottleneck_tab
 from dashboard_components.data_loader import DataLoader
 from dashboard_components.locomotive_tab import render_locomotive_tab
@@ -55,7 +56,7 @@ def main() -> None:
     base_path = Path(base_dir)
 
     if not base_path.exists():
-        st.error(f'❌ Base directory not found: {base_dir}')
+        st.error(f'❌ Base directory not found: {base_dir}'/home/felix/git/duplicate/team-max/scenario-h4r-2-track-fix-base)
         st.stop()
 
     # Scan for scenario folders (folders containing a 'scenario' subdirectory)
@@ -111,6 +112,7 @@ def main() -> None:
             '🏭 Workshops',
             '🛤️ Track Capacity',
             '🚧 Bottleneck Analysis',
+            '🎬 Animation',
         ]
     )
     with tabs[0]:
@@ -133,6 +135,9 @@ def main() -> None:
 
     with tabs[6]:
         render_bottleneck_tab(data)
+
+    with tabs[7]:
+        render_animation_tab(data)
 
     # Footer
     st.sidebar.markdown('---')

--- a/popupsim/frontend/dashboard_components/animation_data.py
+++ b/popupsim/frontend/dashboard_components/animation_data.py
@@ -1,0 +1,918 @@
+"""Pure data transforms for the simulation animation tab.
+
+This module intentionally avoids any Streamlit or Plotly imports so that the
+timeline and motion logic stays fully unit-testable. It turns the raw
+``resource_locations`` / ``resource_states`` event logs and the scenario
+configuration into per-resource movement timelines and per-frame rectangle
+arrays. The yard geometry itself lives in
+:mod:`dashboard_components.animation_layout` (re-exported here for convenience).
+
+Parked resources are compacted **per frame** so wagons stay hole-free: the
+present occupants of a track are packed flush from the far (right) end as a
+LIFO stack (earliest arrival deepest, newest at the throat). Locomotives are
+coupled to the wagons they haul and the consist travels as one rigid, spaced
+train with the loco on the throat side. Wagons are sized by their real length;
+adjacent wagons are told apart by alternating fill shade plus a border.
+"""
+
+from __future__ import annotations
+
+import bisect
+from collections import defaultdict
+from dataclasses import dataclass
+from dataclasses import field
+import math
+from typing import Any
+
+import pandas as pd
+
+from dashboard_components import routes_graph as rg
+from dashboard_components.animation_layout import LANE_SPACING
+from dashboard_components.animation_layout import MAINLINE_DRAWN_M
+from dashboard_components.animation_layout import MIN_TRACK_LEN_M
+from dashboard_components.animation_layout import THROAT_X
+from dashboard_components.animation_layout import TRACK_TYPE_COLORS
+from dashboard_components.animation_layout import TRACK_TYPE_ORDER
+from dashboard_components.animation_layout import TrackLayout
+from dashboard_components.animation_layout import YardLayout
+from dashboard_components.animation_layout import build_layout
+
+__all__ = [
+    'LANE_SPACING',
+    'MAINLINE_DRAWN_M',
+    'MIN_TRACK_LEN_M',
+    'THROAT_X',
+    'TRACK_TYPE_COLORS',
+    'TRACK_TYPE_ORDER',
+    'TrackLayout',
+    'YardLayout',
+    'active_track_ids',
+    'build_frames',
+    'build_layout',
+    'extract_timelines',
+    'parse_capacity_timeline',
+    'rejected_times',
+    'wagon_lengths',
+]
+
+WAGON_COLOR_PENDING: str = '#0072B2'  # blue (Okabe-Ito): not yet retrofitted
+WAGON_COLOR_DONE: str = '#009E73'  # green (Okabe-Ito): retrofitted
+LOCO_COLOR: str = '#2c3e50'  # dark slate, distinct from wagons
+
+# Alternating fill shades so flush (gap-less) neighbours stay individually
+# countable. Index 0 is the base colour; index 1 is a lighter sibling.
+WAGON_SHADES_PENDING: tuple[str, str] = ('#0072B2', '#56B4E9')  # blue / sky-blue
+WAGON_SHADES_DONE: tuple[str, str] = ('#009E73', '#66C2A5')  # green / light green
+
+# Resource dimensions (metres).
+DEFAULT_WAGON_LENGTH_M: float = 16.0
+LOCO_LENGTH_M: float = 19.0
+# Wagons pack flush (no gap): in reality there is no space between coupled
+# wagons. Individual wagons are told apart by alternating fill shade + border
+# rather than by a gap. Kept as a tunable constant (0 = flush).
+UNIFORM_GAP_M: float = 0.0
+
+# Fallback transit duration (simulation minutes) used when an explicit
+# departure time is not available in the event log (e.g. locomotives, which
+# record arrivals via ``previous_location`` but no move-start row).
+DEFAULT_TRANSIT_MIN: float = 12.0
+
+# When inferring which wagons a locomotive hauls, a wagon's transit is matched
+# to a loco move on the same from->to whose timing is within this tolerance
+# (simulation minutes). The loco and wagon event logs use slightly different
+# conventions (the loco logs arrival where the wagon logs departure), so a few
+# minutes of slack is needed.
+CONSIST_MATCH_TOL_MIN: float = 30.0
+
+
+# --- Resource timeline model ------------------------------------------------
+
+
+@dataclass
+class Dwell:
+    """A stationary span of a resource sitting on a track (fixed centre)."""
+
+    track: str
+    t_arrive: float
+    t_depart: float  # math.inf for the final (open-ended) dwell
+    center_x: float = 0.0
+
+
+@dataclass
+class Move:
+    """A transit span of a resource travelling between two tracks."""
+
+    t_depart: float
+    t_arrive: float
+    route: tuple[str, ...]
+    from_track: str
+    to_track: str
+    anchor_from_x: float = 0.0
+    anchor_to_x: float = 0.0
+
+
+@dataclass
+class ResourceTrack:  # pylint: disable=too-many-instance-attributes
+    """Full ordered timeline (dwells + moves) for a single resource."""
+
+    resource_id: str
+    resource_type: str
+    length_m: float = DEFAULT_WAGON_LENGTH_M
+    dwells: list[Dwell] = field(default_factory=list)
+    moves: list[Move] = field(default_factory=list)
+    t_retrofitted: float | None = None
+    first_seen: float = 0.0
+    last_seen: float = 0.0
+
+
+@dataclass
+class ConsistLeg:
+    """One transport leg: a locomotive coupled to a rake of wagons.
+
+    ``car_ids`` / ``car_lengths`` are ordered front-to-back, loco first (it
+    always leads at the throat side); the loco's ``loco_move`` carries the
+    shared window, route and anchored endpoints. Used to render the consist as
+    one rigid train along the route so cars keep their spacing instead of
+    converging over the long mainline run.
+    """
+
+    loco_id: str
+    car_ids: list[str]
+    car_lengths: list[float]
+    t_depart: float
+    t_arrive: float
+    loco_move: Move
+    car_moves: list[Move] = field(default_factory=list)
+
+
+# --- Frame model ------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FrameStats:
+    """Aggregate live statistics for a single animation frame."""
+
+    to_retrofit: int  # wagons present and not yet retrofitted
+    present_retrofitted: int  # retrofitted wagons currently in the system
+    cumulative_retrofitted: int  # wagons retrofitted up to this time
+    cumulative_rejected: int  # wagons rejected up to this time
+    utilization: dict[str, float]  # track id -> occupied length / real length
+
+
+@dataclass(frozen=True)
+class FrameData:  # pylint: disable=too-many-instance-attributes
+    """Rectangle centres + lengths for a single animation frame."""
+
+    t: float
+    datetime_label: str
+    wagon_x: list[float]
+    wagon_y: list[float]
+    wagon_len: list[float]
+    wagon_color: list[str]
+    wagon_ids: list[str]
+    wagon_shade: list[int]
+    loco_x: list[float]
+    loco_y: list[float]
+    loco_len: list[float]
+    loco_ids: list[str]
+    stats: FrameStats
+
+
+# === Movement-segment extraction ============================================
+
+
+def active_track_ids(resource_locations: pd.DataFrame | None, route_graph: rg.RouteGraph | None) -> list[str]:
+    """Return the union of track ids referenced by routes and the event log.
+
+    This is the set of lanes worth drawing — it includes runtime ids (e.g.
+    workshop ``WS_01``) that may not appear verbatim in ``tracks.json``.
+    """
+    ids: set[str] = set()
+    if route_graph is not None:
+        ids |= set(route_graph.track_ids)
+    if resource_locations is not None and not resource_locations.empty and 'location' in resource_locations.columns:
+        ids |= {str(v) for v in resource_locations['location'].dropna().unique() if str(v).strip()}
+    return sorted(ids)
+
+
+def _parse_route(value: Any) -> tuple[str, ...]:
+    """Parse a pipe-delimited ``route_path`` value into a tuple of track ids."""
+    if value is None or (isinstance(value, float) and math.isnan(value)):
+        return ()
+    text = str(value).strip()
+    if not text:
+        return ()
+    return tuple(part for part in text.split('|') if part)
+
+
+def _is_blank(value: Any) -> bool:
+    """Return True for missing / empty cell values."""
+    if value is None:
+        return True
+    if isinstance(value, float) and math.isnan(value):
+        return True
+    return str(value).strip() == ''
+
+
+def _retrofit_times(states: pd.DataFrame | None) -> dict[str, float]:
+    """Map each wagon id to the timestamp it first reaches ``retrofitted``."""
+    if states is None or states.empty or 'state' not in states.columns:
+        return {}
+    done = states[states['state'] == 'retrofitted']
+    if done.empty:
+        return {}
+    grouped = done.groupby('resource_id')['timestamp'].min()
+    return {str(rid): float(ts) for rid, ts in grouped.items()}
+
+
+def wagon_lengths(train_schedule: pd.DataFrame | None) -> dict[str, float]:
+    """Map each wagon id to its real length (metres) from the train schedule."""
+    if train_schedule is None or train_schedule.empty:
+        return {}
+    if 'wagon_id' not in train_schedule.columns or 'length' not in train_schedule.columns:
+        return {}
+    lengths: dict[str, float] = {}
+    for _, row in train_schedule.iterrows():
+        try:
+            lengths[str(row['wagon_id'])] = float(row['length'])
+        except (ValueError, TypeError):
+            continue
+    return lengths
+
+
+def rejected_times(rejected_wagons: pd.DataFrame | None) -> list[float]:
+    """Return sorted rejection timestamps (minutes) for TRACK_FULL rejections only."""
+    if rejected_wagons is None or rejected_wagons.empty or 'timestamp' not in rejected_wagons.columns:
+        return []
+    df = rejected_wagons
+    if 'rejection_type' in df.columns:
+        df = df[df['rejection_type'] == 'TRACK_FULL']
+    times: list[float] = []
+    for value in df['timestamp']:
+        try:
+            times.append(float(value))
+        except (ValueError, TypeError):
+            continue
+    return sorted(times)
+
+
+# --- Capacity timeline (backend reservation events) -------------------------
+
+# Per-track: sorted list of (timestamp, utilization_fraction) pairs.
+CapacityTimeline = dict[str, list[tuple[float, float]]]
+
+
+def parse_capacity_timeline(track_capacity: pd.DataFrame | None) -> CapacityTimeline:
+    """Parse ``track_capacity.csv`` into a per-track step-function of utilization.
+
+    Each track gets a sorted list of ``(timestamp, used_after / capacity)``
+    entries.  Lookup at a given time uses binary search for the last event ≤ t.
+    """
+    if track_capacity is None or track_capacity.empty:
+        return {}
+    required = {'timestamp', 'track_id', 'used_after', 'capacity'}
+    if not required.issubset(track_capacity.columns):
+        return {}
+    timeline: CapacityTimeline = {}
+    for track_id, grp in track_capacity.groupby('track_id', sort=False):
+        entries: list[tuple[float, float]] = []
+        for _, row in grp.sort_values('timestamp').iterrows():
+            cap = float(row['capacity'])
+            if cap <= 0:
+                continue
+            entries.append((float(row['timestamp']), float(row['used_after']) / cap))
+        if entries:
+            timeline[str(track_id)] = entries
+    return timeline
+
+
+def _capacity_util_at(timeline: CapacityTimeline, track_id: str, t: float) -> float | None:
+    """Look up the backend utilization for *track_id* at time *t* (or None if unknown)."""
+    entries = timeline.get(track_id)
+    if not entries:
+        return None
+    idx = bisect.bisect_right(entries, (t, math.inf)) - 1
+    if idx < 0:
+        return 0.0
+    return entries[idx][1]
+
+
+def _build_timeline(resource_id: str, resource_type: str, rows: pd.DataFrame) -> ResourceTrack | None:
+    """Build a single resource timeline from its ordered location rows."""
+    rows = rows.sort_values('timestamp')
+    track = ResourceTrack(resource_id=resource_id, resource_type=resource_type)
+
+    cur_track: str | None = None
+    cur_arrive = 0.0
+    pending_route: tuple[str, ...] = ()
+    pending_depart: float | None = None
+
+    for _, row in rows.iterrows():
+        ts = float(row['timestamp'])
+        location = None if _is_blank(row.get('location')) else str(row['location'])
+        route = _parse_route(row.get('route_path'))
+
+        if cur_track is None:
+            if location is None:
+                continue
+            cur_track, cur_arrive = location, ts
+            track.first_seen = ts
+            continue
+
+        if route:  # move-start marker (wagons)
+            pending_route, pending_depart = route, ts
+
+        if location is not None and location != cur_track:
+            depart = pending_depart if pending_depart is not None else max(cur_arrive, ts - DEFAULT_TRANSIT_MIN)
+            depart = min(max(depart, cur_arrive), ts)
+            track.dwells.append(Dwell(track=cur_track, t_arrive=cur_arrive, t_depart=depart))
+            route_used = pending_route if pending_route else (cur_track, location)
+            track.moves.append(
+                Move(t_depart=depart, t_arrive=ts, route=route_used, from_track=cur_track, to_track=location)
+            )
+            cur_track, cur_arrive = location, ts
+            pending_route, pending_depart = (), None
+
+    if cur_track is not None:
+        track.dwells.append(Dwell(track=cur_track, t_arrive=cur_arrive, t_depart=math.inf))
+        track.last_seen = float(rows['timestamp'].max())
+        return track
+    return None
+
+
+def extract_timelines(
+    resource_locations: pd.DataFrame | None,
+    resource_states: pd.DataFrame | None,
+    lengths: dict[str, float] | None = None,
+) -> dict[str, ResourceTrack]:
+    """Extract per-resource dwell/move timelines from the event logs.
+
+    Wagons use the populated ``route_path`` rows to determine the departure
+    time and the path taken. Locomotives (which only record arrivals via
+    ``previous_location``) fall back to :data:`DEFAULT_TRANSIT_MIN`. ``lengths``
+    maps wagon ids to real lengths (metres); missing wagons fall back to
+    :data:`DEFAULT_WAGON_LENGTH_M` and locomotives to :data:`LOCO_LENGTH_M`.
+    """
+    if resource_locations is None or resource_locations.empty:
+        return {}
+
+    lengths = lengths or {}
+    retrofit = _retrofit_times(resource_states)
+    timelines: dict[str, ResourceTrack] = {}
+    for resource_id, rows in resource_locations.groupby('resource_id'):
+        rid = str(resource_id)
+        rtype = str(rows['resource_type'].iloc[0]) if 'resource_type' in rows.columns else 'wagon'
+        timeline = _build_timeline(rid, rtype, rows)
+        if timeline is None:
+            continue
+        timeline.t_retrofitted = retrofit.get(rid)
+        timeline.length_m = LOCO_LENGTH_M if rtype == 'locomotive' else lengths.get(rid, DEFAULT_WAGON_LENGTH_M)
+        timelines[rid] = timeline
+    return timelines
+
+
+# === Stable position allocation =============================================
+
+
+def _stack_centers(tl: TrackLayout, present: list[tuple[float, bool, str, float]]) -> dict[str, float]:
+    """Pack present resources flush from the far end (away from the throat) as a LIFO stack.
+
+    The earliest arrival sits deepest (against the far end); later arrivals — and
+    locomotives on an arrival tie — sit nearer the throat, where a loco couples.
+    There are never holes: the present set is re-packed every frame, so a
+    departure makes the rest slide flush toward the far end.
+    """
+    order = sorted(present, key=lambda p: (p[0], p[1]))
+    centers: dict[str, float] = {}
+    # Determine packing direction: fill away from the throat toward the far end.
+    if abs(tl.throat_x - tl.x_end) < 1e-9:
+        # Throat is on the right edge (left-zone) → far end is x_start, fill rightward
+        x = tl.x_start
+        for _t_arrive, _is_loco, rid, length in order:
+            centers[rid] = x + length / 2.0
+            x += length + UNIFORM_GAP_M
+    else:
+        # Throat is on the left edge (right-zone / single) → far end is x_end, fill leftward
+        x = tl.x_end
+        for _t_arrive, _is_loco, rid, length in order:
+            centers[rid] = x - length / 2.0
+            x -= length + UNIFORM_GAP_M
+    return centers
+
+
+def _workshop_centers(tl: TrackLayout, present: list[tuple[float, bool, str, float]]) -> dict[str, float]:
+    """Place present workshop occupants in evenly-spaced bay slots inside the box."""
+    order = sorted(present, key=lambda p: (p[0], p[1]))
+    n_slots = max(1, tl.bays or 1, len(order))
+    width = tl.x_end - tl.x_start
+    return {rid: tl.x_start + width * (slot + 0.5) / n_slots for slot, (_ta, _lc, rid, _ln) in enumerate(order)}
+
+
+def _centers_for(tl: TrackLayout | None, present: list[tuple[float, bool, str, float]]) -> dict[str, float]:
+    """Dispatch flush-stack vs workshop-slot packing for a track's occupants."""
+    if tl is None or not present:
+        return {}
+    if tl.is_workshop:
+        return _workshop_centers(tl, present)
+    return _stack_centers(tl, present)
+
+
+def _present_on(timelines: dict[str, ResourceTrack], track_id: str, t: float) -> list[tuple[float, bool, str, float]]:
+    """Return (t_arrive, is_loco, id, length) for resources parked on ``track_id`` at ``t``."""
+    present: list[tuple[float, bool, str, float]] = []
+    for rt in timelines.values():
+        if t < rt.first_seen:
+            continue
+        for dwell in rt.dwells:
+            if dwell.track == track_id and dwell.t_arrive <= t <= dwell.t_depart:
+                present.append((dwell.t_arrive, rt.resource_type == 'locomotive', rt.resource_id, rt.length_m))
+                break
+    return present
+
+
+def _packed_centers(
+    layout: YardLayout, timelines: dict[str, ResourceTrack], track_id: str, t: float
+) -> dict[str, float]:
+    """Return {resource_id: center_x} for the resources parked on ``track_id`` at ``t``."""
+    return _centers_for(layout.tracks.get(track_id), _present_on(timelines, track_id, t))
+
+
+def _all_packed_centers(
+    layout: YardLayout, timelines: dict[str, ResourceTrack], t: float
+) -> dict[str, dict[str, float]]:
+    """Compute packed centres for every occupied track at ``t`` in a single scan."""
+    present_by_track: dict[str, list[tuple[float, bool, str, float]]] = defaultdict(list)
+    for rt in timelines.values():
+        if t < rt.first_seen:
+            continue
+        for dwell in rt.dwells:
+            if dwell.t_arrive <= t <= dwell.t_depart:
+                present_by_track[dwell.track].append(
+                    (dwell.t_arrive, rt.resource_type == 'locomotive', rt.resource_id, rt.length_m)
+                )
+                break
+    return {track: _centers_for(layout.tracks.get(track), items) for track, items in present_by_track.items()}
+
+
+def _mid_x(layout: YardLayout, track_id: str) -> float:
+    """Return a track's mid-x fallback (used when a resource is not found parked)."""
+    tl = layout.tracks.get(track_id)
+    return (tl.x_start + tl.x_end) / 2.0 if tl is not None else 0.0
+
+
+def _anchor_moves(layout: YardLayout, timelines: dict[str, ResourceTrack]) -> None:
+    """Anchor each move to the resource's compacted slot at its endpoints (in place)."""
+    for rt in timelines.values():
+        for move in rt.moves:
+            from_centers = _packed_centers(layout, timelines, move.from_track, move.t_depart)
+            to_centers = _packed_centers(layout, timelines, move.to_track, move.t_arrive)
+            move.anchor_from_x = from_centers.get(rt.resource_id, _mid_x(layout, move.from_track))
+            move.anchor_to_x = to_centers.get(rt.resource_id, _mid_x(layout, move.to_track))
+
+
+def _best_loco_move(wm: Move, candidates: list[tuple[str, int, Move]]) -> tuple[str, int] | None:
+    """Return the (loco_id, move_index) best matching a wagon move, or None."""
+    best_key: tuple[str, int] | None = None
+    best_dist = CONSIST_MATCH_TOL_MIN
+    for loco_id, index, lm in candidates:
+        if lm.from_track != wm.from_track or lm.to_track != wm.to_track:
+            continue
+        dist = min(abs(lm.t_arrive - wm.t_depart), abs(lm.t_depart - wm.t_depart), abs(lm.t_arrive - wm.t_arrive))
+        if dist <= best_dist:
+            best_key, best_dist = (loco_id, index), dist
+    return best_key
+
+
+def infer_consists(timelines: dict[str, ResourceTrack]) -> dict[str, list[ConsistLeg]]:  # pylint: disable=too-many-locals
+    """Couple wagons to the locomotive that hauls them and synchronise motion (in place).
+
+    No data source links a wagon to its loco, so each loco move is matched to the
+    wagons departing the same ``from->to`` at a close time (see
+    :data:`CONSIST_MATCH_TOL_MIN`). For a matched leg the loco move (and its
+    bracketing dwells) is snapped to the rake's window and route — the wagon data
+    is trusted — so the loco and its wagons travel together. Returns the consist
+    legs keyed by every member resource id; unmatched (empty) loco trips produce
+    no leg.
+    """
+    locos = [rt for rt in timelines.values() if rt.resource_type == 'locomotive']
+    wagons = [rt for rt in timelines.values() if rt.resource_type != 'locomotive']
+    by_key: dict[tuple[str, int], tuple[ResourceTrack, Move]] = {}
+    candidates: list[tuple[str, int, Move]] = []
+    for loco in locos:
+        for index, lm in enumerate(loco.moves):
+            by_key[(loco.resource_id, index)] = (loco, lm)
+            candidates.append((loco.resource_id, index, lm))
+
+    rakes: dict[tuple[str, int], list[tuple[ResourceTrack, int, Move]]] = defaultdict(list)
+    for wagon in wagons:
+        for widx, wm in enumerate(wagon.moves):
+            key = _best_loco_move(wm, candidates)
+            if key is not None:
+                rakes[key].append((wagon, widx, wm))
+
+    legs_by_resource: dict[str, list[ConsistLeg]] = defaultdict(list)
+    for key, members in rakes.items():
+        leg = _build_leg(by_key[key], key[1], members)
+        legs_by_resource[leg.loco_id].append(leg)
+        for car_id in leg.car_ids[1:]:
+            legs_by_resource[car_id].append(leg)
+    return dict(legs_by_resource)
+
+
+def _build_leg(
+    loco_move: tuple[ResourceTrack, Move], index: int, members: list[tuple[ResourceTrack, int, Move]]
+) -> ConsistLeg:
+    """Snap a loco move to its rake's window/route and return the consist leg."""
+    loco, lm = loco_move
+    dep = min(wm.t_depart for _w, _i, wm in members)
+    arr = max(wm.t_arrive for _w, _i, wm in members)
+    lm.t_depart, lm.t_arrive = dep, arr
+    lm.route = members[0][2].route or lm.route
+    if index < len(loco.dwells):
+        loco.dwells[index].t_depart = dep
+    if index + 1 < len(loco.dwells):
+        loco.dwells[index + 1].t_arrive = arr
+    # Order wagons newest-first: the latest source arrival sits closest to the
+    # loco (the throat side), matching the flush-stack packing.
+    ordered = sorted(members, key=lambda m: m[0].dwells[m[1]].t_arrive, reverse=True)
+    car_ids = [loco.resource_id, *[w.resource_id for w, _i, _wm in ordered]]
+    car_lengths = [loco.length_m, *[w.length_m for w, _i, _wm in ordered]]
+    car_moves = [lm, *[wm for _w, _i, wm in ordered]]
+    return ConsistLeg(loco.resource_id, car_ids, car_lengths, dep, arr, lm, car_moves)
+
+
+def assign_positions(layout: YardLayout, timelines: dict[str, ResourceTrack]) -> dict[str, list[ConsistLeg]]:
+    """Infer loco/wagon consists, anchor every move, and return the consist legs.
+
+    Parked positions are *not* precomputed: they are compacted per frame (see
+    :func:`_all_packed_centers`) so wagons stay hole-free and slide as neighbours
+    leave. Only move endpoints are anchored here, to the compacted slot the
+    resource occupies at departure / arrival.
+    """
+    legs = infer_consists(timelines)
+    _anchor_moves(layout, timelines)
+    return legs
+
+
+# === Position resolver ======================================================
+
+
+def _move_waypoints(layout: YardLayout, move: Move) -> list[tuple[float, float]]:
+    """Build the route-aware waypoint path for a transit segment.
+
+    In single-column mode the path routes out to the shared vertical throat at
+    each route lane. In three-zone mode it routes to the source track's ladder,
+    and — for cross-zone moves — along the Mainline corridor to the destination
+    zone's ladder, so the resource visibly passes through the Mainline.
+    """
+    a = layout.tracks.get(move.from_track)
+    b = layout.tracks.get(move.to_track)
+    lane_from = a.lane_y if a is not None else 0.0
+    lane_to = b.lane_y if b is not None else 0.0
+    throat_a = a.throat_x if a is not None else layout.throat_x
+    throat_b = b.throat_x if b is not None else layout.throat_x
+    start = (move.anchor_from_x, lane_from)
+    end = (move.anchor_to_x, lane_to)
+
+    if layout.mode != 'zones' or a is None or b is None:
+        points: list[tuple[float, float]] = [start]
+        for track_id in move.route:
+            tl = layout.tracks.get(track_id)
+            if tl is not None:
+                points.append((layout.throat_x, tl.lane_y))
+        points.append(end)
+        return points
+
+    points = [start, (throat_a, lane_from)]
+    if a.zone == b.zone:
+        points.append((throat_a, lane_to))
+    else:  # cross-zone: traverse the Mainline corridor between the two ladders
+        points.extend(
+            [
+                (throat_a, layout.corridor_y),
+                (throat_b, layout.corridor_y),
+                (throat_b, lane_to),
+            ]
+        )
+    points.append(end)
+    return points
+
+
+def _interp_path(points: list[tuple[float, float]], frac: float) -> tuple[float, float]:
+    """Linearly interpolate a position at ``frac`` (0..1) along a polyline."""
+    if frac <= 0.0 or len(points) == 1:
+        return points[0]
+    if frac >= 1.0:
+        return points[-1]
+    seg_lengths = [math.dist(points[i], points[i + 1]) for i in range(len(points) - 1)]
+    total = sum(seg_lengths)
+    if total == 0.0:
+        return points[0]
+    target = frac * total
+    walked = 0.0
+    for i, seg_len in enumerate(seg_lengths):
+        if walked + seg_len >= target:
+            local = 0.0 if seg_len == 0 else (target - walked) / seg_len
+            (x0, y0), (x1, y1) = points[i], points[i + 1]
+            return (x0 + local * (x1 - x0), y0 + local * (y1 - y0))
+        walked += seg_len
+    return points[-1]
+
+
+def _path_length(points: list[tuple[float, float]]) -> float:
+    """Return the total arc length of a polyline."""
+    return sum(math.dist(points[i], points[i + 1]) for i in range(len(points) - 1))
+
+
+def _car_offset(leg: ConsistLeg, idx: int) -> float:
+    """Centre-to-centre arc distance from the loco (index 0) to car ``idx``."""
+    if idx <= 0:
+        return 0.0
+    off = leg.car_lengths[0] / 2.0 + leg.car_lengths[idx] / 2.0
+    for j in range(1, idx):
+        off += leg.car_lengths[j]
+    return off
+
+
+def _covering_leg(legs: list[ConsistLeg] | None, t: float) -> ConsistLeg | None:
+    """Return the consist leg whose window contains ``t`` (or None)."""
+    if not legs:
+        return None
+    for leg in legs:
+        if leg.t_depart <= t <= leg.t_arrive:
+            return leg
+    return None
+
+
+def _consist_position(leg: ConsistLeg, idx: int, layout: YardLayout, t: float) -> tuple[float, float]:
+    """Position car ``idx`` of a consist as part of one rigid, spaced train.
+
+    Every car follows its **own** route (its own compacted source/dest slots),
+    sharing a single progress lagged by the car's offset behind the loco —
+    expressed as a fraction of the loco's path so cars on slightly different-
+    length paths stay evenly spaced. The loco leads out and settles at its
+    throat-side slot first; each wagon tucks into its own (deeper) slot, so the
+    train keeps its spacing over the long mainline run yet lands flush at both
+    ends with no holes and no overlap.
+    """
+    move = leg.car_moves[idx] if idx < len(leg.car_moves) else leg.loco_move
+    path = _move_waypoints(layout, move)
+    ref_len = _path_length(_move_waypoints(layout, leg.loco_move)) or 1.0
+    off_frac = _car_offset(leg, idx) / ref_len
+    tail_frac = _car_offset(leg, len(leg.car_ids) - 1) / ref_len
+    denom = leg.t_arrive - leg.t_depart
+    raw = 0.0 if denom <= 0 else min(1.0, max(0.0, (t - leg.t_depart) / denom))
+    progress = raw * (1.0 + tail_frac)
+    return _interp_path(path, min(1.0, max(0.0, progress - off_frac)))
+
+
+def _resolve_position(
+    rt: ResourceTrack,
+    layout: YardLayout,
+    centers: dict[str, dict[str, float]],
+    legs: dict[str, list[ConsistLeg]],
+    t: float,
+) -> tuple[float, float] | None:
+    """Resolve a resource's (x, y) using per-frame packed ``centers`` and consist ``legs``."""
+    if t < rt.first_seen:
+        return None
+    for dwell in rt.dwells:
+        if dwell.t_arrive <= t <= dwell.t_depart:
+            tl = layout.tracks.get(dwell.track)
+            if tl is None:
+                return None
+            cx = centers.get(dwell.track, {}).get(rt.resource_id)
+            return (cx if cx is not None else _mid_x(layout, dwell.track), tl.lane_y)
+    for move in rt.moves:
+        if move.t_depart <= t <= move.t_arrive:
+            leg = _covering_leg(legs.get(rt.resource_id), t)
+            if leg is not None:
+                return _consist_position(leg, leg.car_ids.index(rt.resource_id), layout, t)
+            denom = move.t_arrive - move.t_depart
+            frac = 0.0 if denom <= 0 else (t - move.t_depart) / denom
+            return _interp_path(_move_waypoints(layout, move), frac)
+    return None
+
+
+def position_at(
+    rt: ResourceTrack,
+    layout: YardLayout,
+    timelines: dict[str, ResourceTrack],
+    t: float,
+    legs: dict[str, list[ConsistLeg]] | None = None,
+) -> tuple[float, float] | None:
+    """Resolve a resource's (x, y) centre at simulation time ``t``.
+
+    Returns ``None`` before the resource first appears. While parked it sits at
+    its compacted (hole-free, flush-right) slot among co-present resources; while
+    moving it follows its route — as part of a rigid consist when ``legs`` says
+    so. Requires :func:`assign_positions` to have been run on ``timelines`` (pass
+    its returned ``legs`` for coupled movement).
+    """
+    return _resolve_position(rt, layout, _all_packed_centers(layout, timelines, t), legs or {}, t)
+
+
+# === Frame builder ==========================================================
+
+
+def sim_time_bounds(timelines: dict[str, ResourceTrack]) -> tuple[float, float]:
+    """Return the (start, end) simulation time spanning all resources."""
+    if not timelines:
+        return (0.0, 0.0)
+    start = min(rt.first_seen for rt in timelines.values())
+    end = max(rt.last_seen for rt in timelines.values())
+    if end <= start:
+        end = start + 1.0
+    return (start, end)
+
+
+def _wagon_color(rt: ResourceTrack, t: float) -> str:
+    """Return the wagon colour at time ``t`` (green once retrofitted)."""
+    if rt.t_retrofitted is not None and t >= rt.t_retrofitted:
+        return WAGON_COLOR_DONE
+    return WAGON_COLOR_PENDING
+
+
+def _empty_acc() -> dict[str, list[Any]]:
+    """Return empty per-category arrays for a frame under construction."""
+    return {
+        'wagon_x': [],
+        'wagon_y': [],
+        'wagon_len': [],
+        'wagon_color': [],
+        'wagon_ids': [],
+        'loco_x': [],
+        'loco_y': [],
+        'loco_len': [],
+        'loco_ids': [],
+    }
+
+
+def _shade_indices(xs: list[float], ys: list[float]) -> list[int]:
+    """Assign an alternating 0/1 shade per wagon, by position along each lane.
+
+    Wagons on the same lane (same ``y``) are ranked left-to-right; the shade is
+    the rank parity, so flush neighbours render in alternating brightness and
+    can be told apart without a gap.
+    """
+    shades = [0] * len(xs)
+    order = sorted(range(len(xs)), key=lambda i: (ys[i], xs[i]))
+    prev_y: float | None = None
+    rank = 0
+    for i in order:
+        if ys[i] != prev_y:
+            prev_y, rank = ys[i], 0
+        shades[i] = rank % 2
+        rank += 1
+    return shades
+
+
+def _dwell_track_at(rt: ResourceTrack, t: float) -> str | None:
+    """Return the track a resource is parked on at ``t`` (None while in transit)."""
+    if t < rt.first_seen:
+        return None
+    for dwell in rt.dwells:
+        if dwell.t_arrive <= t <= dwell.t_depart:
+            return dwell.track
+    return None
+
+
+def _frame_stats(  # pylint: disable=too-many-locals
+    layout: YardLayout,
+    timelines: dict[str, ResourceTrack],
+    t: float,
+    rejected_at: list[float],
+    capacity_timeline: CapacityTimeline | None = None,
+) -> FrameStats:
+    """Compute the aggregate live statistics for simulation time ``t``."""
+    to_retrofit = present_done = cumulative_done = 0
+    occupied: dict[str, float] = defaultdict(float)
+    for rt in timelines.values():
+        if rt.resource_type == 'locomotive':
+            continue
+        done = rt.t_retrofitted is not None and t >= rt.t_retrofitted
+        cumulative_done += 1 if done else 0
+        present = t >= rt.first_seen
+        if present:
+            present_done += 1 if done else 0
+            to_retrofit += 0 if done else 1
+            track = _dwell_track_at(rt, t)
+            if track is not None:
+                occupied[track] += rt.length_m
+
+    utilization: dict[str, float] = {}
+    for track_id, tl in layout.tracks.items():
+        if tl.track_type == 'mainline' or tl.length_m <= 0:
+            continue
+        if capacity_timeline:
+            cap_val = _capacity_util_at(capacity_timeline, track_id, t)
+            if cap_val is not None:
+                utilization[track_id] = cap_val
+                continue
+        utilization[track_id] = occupied.get(track_id, 0.0) / tl.length_m
+
+    cumulative_rejected = sum(1 for rt_t in rejected_at if rt_t <= t)
+    return FrameStats(
+        to_retrofit=to_retrofit,
+        present_retrofitted=present_done,
+        cumulative_retrofitted=cumulative_done,
+        cumulative_rejected=cumulative_rejected,
+        utilization=utilization,
+    )
+
+
+def _collect_frame_arrays(
+    layout: YardLayout, timelines: dict[str, ResourceTrack], legs: dict[str, list[ConsistLeg]], t: float
+) -> dict[str, list[Any]]:
+    """Accumulate per-resource rectangle arrays for a single frame."""
+    acc = _empty_acc()
+    centers = _all_packed_centers(layout, timelines, t)
+    for rt in timelines.values():
+        pos = _resolve_position(rt, layout, centers, legs, t)
+        if pos is None:
+            continue
+        if rt.resource_type == 'locomotive':
+            acc['loco_x'].append(pos[0])
+            acc['loco_y'].append(pos[1])
+            acc['loco_len'].append(rt.length_m)
+            acc['loco_ids'].append(rt.resource_id)
+        else:
+            acc['wagon_x'].append(pos[0])
+            acc['wagon_y'].append(pos[1])
+            acc['wagon_len'].append(rt.length_m)
+            acc['wagon_color'].append(_wagon_color(rt, t))
+            acc['wagon_ids'].append(rt.resource_id)
+    return acc
+
+
+@dataclass(frozen=True)
+class _FrameInputs:
+    """Shared inputs for building every frame of one animation."""
+
+    layout: YardLayout
+    timelines: dict[str, ResourceTrack]
+    legs: dict[str, list[ConsistLeg]]
+    rejected_at: list[float]
+    t_start: float
+    capacity_timeline: CapacityTimeline
+
+
+def _build_one_frame(inputs: _FrameInputs, t: float) -> FrameData:
+    """Assemble a single :class:`FrameData` (rectangles + shades + stats) at ``t``."""
+    acc = _collect_frame_arrays(inputs.layout, inputs.timelines, inputs.legs, t)
+    return FrameData(
+        t=t,
+        datetime_label=_format_time(inputs.t_start, t),
+        wagon_x=acc['wagon_x'],
+        wagon_y=acc['wagon_y'],
+        wagon_len=acc['wagon_len'],
+        wagon_color=acc['wagon_color'],
+        wagon_ids=acc['wagon_ids'],
+        wagon_shade=_shade_indices(acc['wagon_x'], acc['wagon_y']),
+        loco_x=acc['loco_x'],
+        loco_y=acc['loco_y'],
+        loco_len=acc['loco_len'],
+        loco_ids=acc['loco_ids'],
+        stats=_frame_stats(inputs.layout, inputs.timelines, t, inputs.rejected_at, inputs.capacity_timeline),
+    )
+
+
+def build_frames(  # noqa: PLR0913  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    layout: YardLayout,
+    timelines: dict[str, ResourceTrack],
+    num_frames: int,
+    bounds: tuple[float, float] | None = None,
+    rejected_at: list[float] | None = None,
+    capacity_timeline: CapacityTimeline | None = None,
+) -> list[FrameData]:
+    """Build the per-frame rectangle arrays over a uniform simulation-time grid.
+
+    ``num_frames`` (the user-selected resolution) sets the grid density. Each
+    frame carries wagon / locomotive rectangle centres + lengths + colours,
+    per-wagon shade indices, and aggregate live :class:`FrameStats`.
+    ``rejected_at`` lists rejection timestamps (minutes) for the cumulative
+    rejected-wagon counter.
+    """
+    if not timelines or num_frames < 1:
+        return []
+    legs = assign_positions(layout, timelines)
+    t_start, t_end = bounds if bounds is not None else sim_time_bounds(timelines)
+    span = t_end - t_start
+    inputs = _FrameInputs(layout, timelines, legs, rejected_at or [], t_start, capacity_timeline or {})
+
+    frames: list[FrameData] = []
+    for index in range(num_frames):
+        frac = 0.0 if num_frames == 1 else index / (num_frames - 1)
+        frames.append(_build_one_frame(inputs, t_start + frac * span))
+    return frames
+
+
+def _format_time(t_start: float, t: float) -> str:
+    """Format a simulation timestamp (minutes) as an elapsed D/H:M label."""
+    elapsed = t - t_start
+    days = int(elapsed // (24 * 60))
+    hours = int((elapsed % (24 * 60)) // 60)
+    minutes = int(elapsed % 60)
+    if days > 0:
+        return f'Day {days + 1} {hours:02d}:{minutes:02d}'
+    return f'{hours:02d}:{minutes:02d}'

--- a/popupsim/frontend/dashboard_components/animation_layout.py
+++ b/popupsim/frontend/dashboard_components/animation_layout.py
@@ -1,0 +1,286 @@
+"""Schematic yard geometry for the simulation animation.
+
+Builds the metric track-lane layout used by :mod:`dashboard_components.animation_data`:
+three zones when routes span the Mainline (local yard on the left, Mainline
+corridor in the middle, remote/arrival storage on the right), or a single
+stacked column otherwise. Kept free of Streamlit / Plotly imports so the
+geometry stays unit-testable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from dashboard_components import routes_graph as rg
+
+# --- Visual constants (mirrors scenario_tab for consistency) ----------------
+
+TRACK_TYPE_ORDER: list[str] = [
+    'mainline',
+    'collection',
+    'retrofit',
+    'workshop',
+    'retrofitted',
+    'parking',
+    'rescource_parking',
+]
+
+TRACK_TYPE_COLORS: dict[str, str] = {
+    'collection': '#e74c3c',
+    'retrofit': '#f39c12',
+    'workshop': '#27ae60',
+    'retrofitted': '#9b59b6',
+    'parking': '#34495e',
+    'mainline': '#95a5a6',
+    'rescource_parking': '#7f8c8d',
+}
+
+# Geometry. The x-axis is in metres along the track.
+THROAT_X: float = 0.0
+LANE_SPACING: float = 1.0
+MIN_TRACK_LEN_M: float = 40.0  # floor so very short tracks stay visible
+MAINLINE_DRAWN_M: float = 300.0  # mainline is transit-only; not drawn to scale
+
+
+@dataclass(frozen=True)
+class TrackLayout:  # pylint: disable=too-many-instance-attributes
+    """Geometry for a single track lane in the schematic yard."""
+
+    track_id: str
+    track_type: str
+    lane_y: float
+    x_start: float
+    x_end: float
+    length_m: float
+    color: str
+    is_workshop: bool = False
+    bays: int | None = None
+    cluster: str = 'local'
+    throat_x: float = 0.0  # x of the connecting (ladder) end of the track
+    zone: str = 'single'  # 'single' | 'left' | 'middle' | 'right'
+
+
+@dataclass(frozen=True)
+class YardLayout:  # pylint: disable=too-many-instance-attributes
+    """Full schematic layout: track lanes plus connecting throat(s).
+
+    In ``zones`` mode: left zone = local yard (ladder on its right edge),
+    middle = Mainline corridor, right zone = remote/arrival storage (ladder on
+    its left edge). In ``single`` mode: one vertical throat at ``throat_x``.
+    """
+
+    tracks: dict[str, TrackLayout]
+    throat_x: float
+    x_max: float
+    y_min: float
+    y_max: float
+    mode: str = 'single'  # 'single' | 'zones'
+    left_throat_x: float = 0.0
+    right_throat_x: float = 0.0
+    corridor_y: float = 0.0
+
+
+def _natural_key(track_id: str) -> tuple[str, int]:
+    """Return a sort key that orders ``parking2`` before ``parking10``."""
+    digits = ''.join(ch for ch in track_id if ch.isdigit())
+    prefix = ''.join(ch for ch in track_id if not ch.isdigit())
+    return (prefix, int(digits) if digits else 0)
+
+
+def _edge_length(topology: dict[str, Any], edges: list[str]) -> float:
+    """Sum the lengths of the given topology edges (0.0 if unknown)."""
+    edge_map = topology.get('edges', {}) if topology else {}
+    total = 0.0
+    for edge in edges:
+        info = edge_map.get(edge)
+        if isinstance(info, dict) and 'length' in info:
+            total += float(info['length'])
+    return total
+
+
+def _resolve_track_meta(
+    track_id: str,
+    tracks_by_id: dict[str, dict[str, Any]],
+    topology: dict[str, Any],
+    bays_by_id: dict[str, int],
+    default_ws_len: float,
+) -> tuple[str, float, int | None]:
+    """Resolve (track_type, length_m, bays) for a track id, robust to id drift.
+
+    Handles scenarios where the runtime/route id (e.g. workshop ``WS_01``) does
+    not match the ``tracks.json`` id (``WS1``): such ids fall back to the
+    workshop config for type/bays and a default workshop length.
+    """
+    if track_id in tracks_by_id:
+        track = tracks_by_id[track_id]
+        track_type = str(track.get('type', 'parking'))
+        length_m = _edge_length(topology, track.get('edges', [track_id]))
+        bays = bays_by_id.get(track_id) if track_type == 'workshop' else None
+        return track_type, length_m, bays
+    if track_id in bays_by_id:  # a workshop id with no matching track entry
+        return 'workshop', default_ws_len, bays_by_id[track_id]
+    if track_id == rg.MAINLINE:
+        return 'mainline', _edge_length(topology, [track_id]), None
+    return 'parking', _edge_length(topology, [track_id]) or MIN_TRACK_LEN_M, None
+
+
+def build_layout(  # pylint: disable=too-many-locals
+    tracks_config: list[dict[str, Any]],
+    topology: dict[str, Any],
+    workshops_config: list[dict[str, Any]] | None = None,
+    route_graph: rg.RouteGraph | None = None,
+    active_ids: list[str] | None = None,
+) -> YardLayout:
+    """Build a schematic yard layout from scenario configuration.
+
+    When a remote cluster exists (routes span the Mainline), the layout uses
+    three zones: local yard on the left (tracks extend left from a right-edge
+    ladder), Mainline corridor in the middle, and remote storage on the right
+    (tracks extend right from a left-edge ladder). Otherwise a single stacked
+    column with a shared left-edge throat is used.
+
+    ``active_ids`` (when given) selects which tracks to lay out — typically the
+    union of ids referenced by routes and the event logs.
+    """
+    workshops_config = workshops_config or []
+    tracks_by_id = {str(t['id']): t for t in tracks_config}
+    bays_by_id = {str(s['id']): int(s.get('retrofit_stations', 0)) for s in workshops_config if s.get('id')}
+    ws_lengths = [
+        _edge_length(topology, t.get('edges', [t['id']])) for t in tracks_config if t.get('type') == 'workshop'
+    ]
+    default_ws_len = max((length for length in ws_lengths if length > 0), default=260.0)
+
+    ids = active_ids if active_ids else [str(t['id']) for t in tracks_config]
+    cluster_of = route_graph.cluster if route_graph else {}
+
+    enriched: list[dict[str, Any]] = []
+    for track_id in dict.fromkeys(ids):  # de-duplicate, preserve order
+        track_type, length_m, bays = _resolve_track_meta(track_id, tracks_by_id, topology, bays_by_id, default_ws_len)
+        enriched.append(
+            {
+                'id': track_id,
+                'type': track_type,
+                'length_m': length_m,
+                'bays': bays,
+                'cluster': cluster_of.get(track_id, 'local'),
+            }
+        )
+
+    if route_graph is not None and any(t['cluster'] == 'remote' for t in enriched):
+        return _layout_zones(enriched)
+    return _layout_single(enriched)
+
+
+def _order_index(track_type: str) -> int:
+    """Return the top-to-bottom rank of a track type."""
+    return TRACK_TYPE_ORDER.index(track_type) if track_type in TRACK_TYPE_ORDER else len(TRACK_TYPE_ORDER)
+
+
+def _drawn_len(track_type: str, length_m: float) -> float:
+    """Return the drawn x-extent (metres) of a track (mainline is fixed)."""
+    return MAINLINE_DRAWN_M if track_type == 'mainline' else max(MIN_TRACK_LEN_M, length_m)
+
+
+def _make_track(
+    track: dict[str, Any], lane_y: float, x_range: tuple[float, float], throat_x: float, zone: str
+) -> TrackLayout:
+    """Build a TrackLayout from an enriched track dict and geometry."""
+    track_type = track['type']
+    return TrackLayout(
+        track_id=track['id'],
+        track_type=track_type,
+        lane_y=lane_y,
+        x_start=x_range[0],
+        x_end=x_range[1],
+        length_m=track['length_m'],
+        color=TRACK_TYPE_COLORS.get(track_type, '#7f7f7f'),
+        is_workshop=track_type == 'workshop',
+        bays=track['bays'],
+        cluster=track['cluster'],
+        throat_x=throat_x,
+        zone=zone,
+    )
+
+
+def _layout_single(enriched: list[dict[str, Any]]) -> YardLayout:
+    """Lay out all tracks as a single vertically-stacked column."""
+    enriched.sort(key=lambda t: (rg.CLUSTER_RANK.get(t['cluster'], 2), _order_index(t['type']), _natural_key(t['id'])))
+    n_lanes = len(enriched)
+    tracks: dict[str, TrackLayout] = {}
+    for index, track in enumerate(enriched):
+        drawn = _drawn_len(track['type'], track['length_m'])
+        tracks[track['id']] = _make_track(
+            track, (n_lanes - 1 - index) * LANE_SPACING, (THROAT_X, THROAT_X + drawn), THROAT_X, 'single'
+        )
+    y_values = [t.lane_y for t in tracks.values()] or [0.0]
+    x_values = [t.x_end for t in tracks.values()] or [MAINLINE_DRAWN_M]
+    return YardLayout(
+        tracks=tracks,
+        throat_x=THROAT_X,
+        x_max=max(x_values),
+        y_min=min(y_values),
+        y_max=max(y_values),
+        mode='single',
+        left_throat_x=THROAT_X,
+    )
+
+
+def _layout_zones(enriched: list[dict[str, Any]]) -> YardLayout:  # pylint: disable=too-many-locals
+    """Lay out tracks in three columns: local yard | Mainline | remote storage.
+
+    The local yard sits on the left (ladder on its right edge, tracks extend
+    left), the Mainline is a fixed-width corridor in the middle, and the remote
+    storage sits on the right (ladder on its left edge, tracks extend right).
+    """
+    left = sorted(
+        (t for t in enriched if t['type'] != 'mainline' and t['cluster'] in ('local', 'hub')),
+        key=lambda t: (_order_index(t['type']), _natural_key(t['id'])),
+    )
+    right = sorted(
+        (t for t in enriched if t['type'] != 'mainline' and t['cluster'] == 'remote'),
+        key=lambda t: (_order_index(t['type']), _natural_key(t['id'])),
+    )
+
+    left_w = max((_drawn_len(t['type'], t['length_m']) for t in left), default=MIN_TRACK_LEN_M)
+    right_w = max((_drawn_len(t['type'], t['length_m']) for t in right), default=MIN_TRACK_LEN_M)
+    middle_w = (left_w + right_w) / 3.0
+    left_throat = left_w
+    right_throat = left_w + middle_w
+    total_w = left_w + middle_w + right_w
+    n_lanes = max(len(left), len(right), 1)
+    corridor_y = -LANE_SPACING
+
+    tracks: dict[str, TrackLayout] = {}
+
+    def lane_for(group: list[dict[str, Any]], index: int) -> float:
+        offset = (n_lanes - len(group)) / 2.0
+        return (n_lanes - 1 - index - offset) * LANE_SPACING
+
+    for index, track in enumerate(left):
+        drawn = _drawn_len(track['type'], track['length_m'])
+        tracks[track['id']] = _make_track(
+            track, lane_for(left, index), (left_throat - drawn, left_throat), left_throat, 'left'
+        )
+    for index, track in enumerate(right):
+        drawn = _drawn_len(track['type'], track['length_m'])
+        tracks[track['id']] = _make_track(
+            track, lane_for(right, index), (right_throat, right_throat + drawn), right_throat, 'right'
+        )
+    for track in (t for t in enriched if t['type'] == 'mainline'):
+        tracks[track['id']] = _make_track(
+            track, corridor_y, (left_throat, right_throat), (left_throat + right_throat) / 2.0, 'middle'
+        )
+
+    y_values = [t.lane_y for t in tracks.values()] or [0.0]
+    return YardLayout(
+        tracks=tracks,
+        throat_x=left_throat,
+        x_max=total_w,
+        y_min=min(y_values),
+        y_max=max(y_values),
+        mode='zones',
+        left_throat_x=left_throat,
+        right_throat_x=right_throat,
+        corridor_y=corridor_y,
+    )

--- a/popupsim/frontend/dashboard_components/animation_tab.py
+++ b/popupsim/frontend/dashboard_components/animation_tab.py
@@ -1,0 +1,664 @@
+"""Animation tab - animated playback of a simulation run.
+
+Renders a schematic yard (metric track lanes + a connecting throat) and plays
+back wagon / locomotive movements over time using Plotly's native frame
+animation (client-side play / pause / scrub). Resources are drawn as flat,
+non-overlapping, train-like rectangles sized by their real length.
+
+All heavy data preparation lives in
+:mod:`dashboard_components.animation_data` (pure, unit-tested); this module
+only handles Streamlit controls and Plotly figure assembly.
+"""
+
+from string import Template
+from typing import Any
+
+import pandas as pd
+import plotly.graph_objects as go
+import plotly.io as pio
+import streamlit as st
+import streamlit.components.v1 as components
+
+from dashboard_components import animation_data as ad
+from dashboard_components import routes_graph as rg
+
+# Rectangle height in lane units (nominal: the y-axis is a lane index, not
+# metric, so true 3 m would render as an invisible hairline against a yard that
+# is hundreds of metres tall). Length, by contrast, is true-to-metre.
+_RECT_HEIGHT = 0.5
+_LANE_HALF_HEIGHT = 0.36
+_TRACK_LINE_WIDTH = 5
+_LABEL_OFFSET_M = 14.0
+_MIN_FRAME_MS = 20
+
+# Selectable animation resolutions on a roughly quadratic scale: fine steps at
+# the low end, coarse jumps toward the (very large) high end.
+_RESOLUTION_OPTIONS = [200, 300, 500, 900, 1500, 2200, 3100, 4200, 5400, 6800, 8300, 10000]
+# Above this many frames the embedded figure JSON gets large and the browser
+# may become sluggish, so we surface a heads-up.
+_HEAVY_FRAME_COUNT = 2000
+
+# The animated figure is embedded as raw HTML (not via ``st.plotly_chart``) so
+# that custom previous/next buttons can drive ``Plotly.animate`` entirely in the
+# browser, staying in sync with the native play/pause and slider.
+_PLOT_DIV_ID = 'yard-animation'
+# ``string.Template`` ($-substitution) avoids escaping every brace in the JS.
+_CONTROLS_TEMPLATE = Template(
+    """
+<div class="yard-controls">
+  <button type="button" id="${div}-prev" class="yard-btn">⏮ Previous frame</button>
+  <button type="button" id="${div}-next" class="yard-btn">⏭ Next frame</button>
+  <span class="yard-frame" id="${div}-label"></span>
+</div>
+<style>
+  .yard-controls { display:flex; align-items:center; gap:8px; margin:2px 0 0 6px;
+                   font-family:"Source Sans Pro",sans-serif; }
+  .yard-btn { padding:4px 12px; border:1px solid #ccc; border-radius:6px;
+              background:#f6f6f6; cursor:pointer; font-size:14px; }
+  .yard-btn:hover { background:#e9e9e9; }
+  .yard-frame { color:#555; font-size:13px; }
+</style>
+<script>
+(function() {
+  var divId = "$div";
+  var N = $n;
+  var cur = 0;
+  function gd() { return document.getElementById(divId); }
+  function clamp(i) { return Math.max(0, Math.min(N - 1, i)); }
+  function refresh() {
+    var label = document.getElementById(divId + "-label");
+    if (label) { label.textContent = "Frame " + (cur + 1) + " / " + N; }
+  }
+  function go(i) {
+    cur = clamp(i);
+    Plotly.animate(gd(), [String(cur)],
+      {mode: "immediate", frame: {duration: 0, redraw: true}, transition: {duration: 0}});
+    refresh();
+  }
+  function wire() {
+    document.getElementById(divId + "-prev").addEventListener("click", function() { go(cur - 1); });
+    document.getElementById(divId + "-next").addEventListener("click", function() { go(cur + 1); });
+    // The native play button and slider both animate by frame name, so this one
+    // handler keeps "cur" in sync with every kind of navigation.
+    gd().on("plotly_animatingframe", function(e) {
+      if (e && e.name !== undefined && e.name !== null) {
+        var idx = parseInt(e.name, 10);
+        if (!isNaN(idx)) { cur = idx; refresh(); }
+      }
+    });
+    refresh();
+  }
+  function ready() {
+    var g = gd();
+    if (window.Plotly && g && g._fullLayout) { wire(); }
+    else { setTimeout(ready, 60); }
+  }
+  ready();
+})();
+</script>
+"""
+)
+
+
+@st.cache_data(show_spinner=False)
+def _compute_animation(  # noqa: PLR0913  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    resource_locations: pd.DataFrame | None,
+    resource_states: pd.DataFrame | None,
+    layout_config: dict[str, Any],
+    num_frames: int,
+    rejected_wagons: pd.DataFrame | None = None,
+    track_capacity: pd.DataFrame | None = None,
+) -> tuple[ad.YardLayout, list[ad.FrameData]]:
+    """Build (and cache) the yard layout and per-frame rectangle arrays.
+
+    Cached on the raw inputs + resolution so scrubbing/replaying is instant.
+    ``layout_config`` bundles the ``tracks`` / ``topology`` / ``workshops`` /
+    ``routes`` config plus the ``wagon_lengths`` map. ``rejected_wagons`` feeds
+    the cumulative rejected-wagon counter.
+    """
+    route_graph = rg.parse_routes(layout_config.get('routes'))
+    active = ad.active_track_ids(resource_locations, route_graph)
+    layout = ad.build_layout(
+        layout_config.get('tracks', []),
+        layout_config.get('topology', {}),
+        layout_config.get('workshops', []),
+        route_graph,
+        active,
+    )
+    timelines = ad.extract_timelines(resource_locations, resource_states, layout_config.get('wagon_lengths', {}))
+    cap_tl = ad.parse_capacity_timeline(track_capacity)
+    frames = ad.build_frames(
+        layout, timelines, num_frames, rejected_at=ad.rejected_times(rejected_wagons), capacity_timeline=cap_tl
+    )
+    return layout, frames
+
+
+def _rect_polygons(
+    xs: list[float], ys: list[float], lengths: list[float]
+) -> tuple[list[float | None], list[float | None]]:
+    """Build None-separated polygon corner arrays for a set of rectangles."""
+    poly_x: list[float | None] = []
+    poly_y: list[float | None] = []
+    half_h = _RECT_HEIGHT / 2.0
+    for xc, yc, length in zip(xs, ys, lengths, strict=False):
+        half_l = length / 2.0
+        poly_x.extend([xc - half_l, xc + half_l, xc + half_l, xc - half_l, xc - half_l, None])
+        poly_y.extend([yc - half_h, yc - half_h, yc + half_h, yc + half_h, yc - half_h, None])
+    return poly_x, poly_y
+
+
+def _rect_trace(xs: list[float], ys: list[float], lengths: list[float], color: str, line_color: str) -> go.Scatter:
+    """Build a single filled-rectangle Scatter trace (one colour group)."""
+    poly_x, poly_y = _rect_polygons(xs, ys, lengths)
+    return go.Scatter(
+        x=poly_x,
+        y=poly_y,
+        mode='lines',
+        fill='toself',
+        fillcolor=color,
+        line={'color': line_color, 'width': 1.1},
+        hoverinfo='skip',
+        showlegend=False,
+    )
+
+
+_WAGON_BORDER_PENDING = '#013a63'
+_WAGON_BORDER_DONE = '#04503a'
+_LOCO_BORDER = '#f1c40f'
+_STATS_FONT = {'size': 17, 'color': '#2c3e50'}
+_UTIL_FONT_SIZE = 16
+_UTIL_OFFSET_M = 30.0  # gap past a track's throat end for its utilization label (toward middle)
+
+
+def _wagon_groups(frame: ad.FrameData) -> dict[tuple[str, int], dict[str, list[float]]]:
+    """Group a frame's wagons by (status, shade) so each renders in its own shade."""
+    groups: dict[tuple[str, int], dict[str, list[float]]] = {
+        (status, shade): {'x': [], 'y': [], 'len': []} for status in ('pending', 'done') for shade in (0, 1)
+    }
+    rows = zip(frame.wagon_x, frame.wagon_y, frame.wagon_len, frame.wagon_color, frame.wagon_shade, strict=False)
+    for x, y, length, color, shade in rows:
+        status = 'done' if color == ad.WAGON_COLOR_DONE else 'pending'
+        group = groups[(status, shade)]
+        group['x'].append(x)
+        group['y'].append(y)
+        group['len'].append(length)
+    return groups
+
+
+def _label_trace(frame: ad.FrameData, show_labels: bool) -> go.Scatter:
+    """Build the hover/label trace carrying every resource id."""
+    return go.Scatter(
+        x=frame.wagon_x + frame.loco_x,
+        y=frame.wagon_y + frame.loco_y,
+        mode='markers+text' if show_labels else 'markers',
+        marker={'size': 12, 'color': 'rgba(0,0,0,0)'},
+        text=frame.wagon_ids + frame.loco_ids,
+        textposition='middle center',
+        textfont={'size': 6, 'color': '#ffffff'},
+        hovertemplate='%{text}<extra></extra>',
+        showlegend=False,
+    )
+
+
+def _counters_trace(frame: ad.FrameData, layout: ad.YardLayout) -> go.Scatter:
+    """Build the live counters text block, placed above the layout."""
+    s = frame.stats
+    text = (
+        f'<b>To retrofit: {s.to_retrofit}<br>'
+        f'Retrofitted: {s.cumulative_retrofitted}<br>'
+        f'Rejected: {s.cumulative_rejected}</b>'
+    )
+    if layout.mode == 'zones':
+        x = (layout.left_throat_x + layout.right_throat_x) / 2.0
+        y = layout.y_max + 0.7
+    else:
+        x = layout.x_max * 0.5
+        y = layout.y_max + 0.5
+    return go.Scatter(
+        x=[x],
+        y=[y],
+        mode='text',
+        text=[text],
+        textposition='middle center',
+        textfont=_STATS_FONT,
+        hoverinfo='skip',
+        showlegend=False,
+    )
+
+
+def _utilization_trace(frame: ad.FrameData, layout: ad.YardLayout) -> go.Scatter:
+    """Build the per-track capacity-usage labels (one '%' per non-mainline lane)."""
+    xs: list[float] = []
+    ys: list[float] = []
+    texts: list[str] = []
+    colors: list[str] = []
+    for track_id, usage in frame.stats.utilization.items():
+        tl = layout.tracks.get(track_id)
+        if tl is None:
+            continue
+        # Place the label on the throat (inner) side: right of throat for the
+        # left panel, left of throat for the right panel.
+        if abs(tl.throat_x - tl.x_end) < 1e-9:
+            xs.append(tl.x_end + _UTIL_OFFSET_M)
+        else:
+            xs.append(tl.x_start - _UTIL_OFFSET_M)
+        ys.append(tl.lane_y)
+        texts.append(f'{usage * 100:.0f}%')
+        colors.append('#c0392b' if usage > 1.0 else '#34495e')
+    return go.Scatter(
+        x=xs,
+        y=ys,
+        mode='text',
+        text=texts,
+        textposition='middle center',
+        textfont={'size': _UTIL_FONT_SIZE, 'color': colors or '#34495e'},
+        hoverinfo='skip',
+        showlegend=False,
+    )
+
+
+def _dynamic_traces(frame: ad.FrameData, layout: ad.YardLayout, show_labels: bool) -> list[go.Scatter]:
+    """Build the per-frame traces (4 wagon shade groups, locos, labels, stats)."""
+    groups = _wagon_groups(frame)
+    return [
+        _rect_trace(*_unpack(groups[('pending', 0)]), ad.WAGON_SHADES_PENDING[0], _WAGON_BORDER_PENDING),
+        _rect_trace(*_unpack(groups[('pending', 1)]), ad.WAGON_SHADES_PENDING[1], _WAGON_BORDER_PENDING),
+        _rect_trace(*_unpack(groups[('done', 0)]), ad.WAGON_SHADES_DONE[0], _WAGON_BORDER_DONE),
+        _rect_trace(*_unpack(groups[('done', 1)]), ad.WAGON_SHADES_DONE[1], _WAGON_BORDER_DONE),
+        _rect_trace(frame.loco_x, frame.loco_y, frame.loco_len, ad.LOCO_COLOR, _LOCO_BORDER),
+        _label_trace(frame, show_labels),
+        _counters_trace(frame, layout),
+        _utilization_trace(frame, layout),
+    ]
+
+
+_DYNAMIC_TRACE_COUNT = 8
+
+
+def _unpack(group: dict[str, list[float]]) -> tuple[list[float], list[float], list[float]]:
+    """Return the (x, y, len) arrays of a wagon group."""
+    return group['x'], group['y'], group['len']
+
+
+def _legend_traces() -> list[go.Scatter]:
+    """Legend-only marker traces (no data points)."""
+    entries = [
+        ('Wagon · to retrofit', ad.WAGON_COLOR_PENDING, 'square'),
+        ('Wagon · retrofitted', ad.WAGON_COLOR_DONE, 'square'),
+        ('Locomotive', ad.LOCO_COLOR, 'square'),
+        ('Workshop', ad.TRACK_TYPE_COLORS['workshop'], 'square'),
+    ]
+    return [
+        go.Scatter(
+            x=[None],
+            y=[None],
+            mode='markers',
+            name=name,
+            marker={'color': color, 'symbol': symbol, 'size': 12, 'line': {'color': '#222', 'width': 1}},
+            showlegend=True,
+            hoverinfo='skip',
+        )
+        for name, color, symbol in entries
+    ]
+
+
+def _add_static_geometry(fig: go.Figure, layout: ad.YardLayout) -> None:
+    """Draw the static yard skeleton, dispatching on the layout mode."""
+    if layout.mode == 'zones':
+        _add_zone_geometry(fig, layout)
+    else:
+        _add_single_geometry(fig, layout)
+
+
+def _track_line(fig: go.Figure, tl: ad.TrackLayout) -> None:
+    """Draw a single track as a workshop box or a plain horizontal line."""
+    if tl.is_workshop:
+        _draw_workshop(fig, tl)
+    else:
+        fig.add_shape(
+            type='line',
+            x0=tl.x_start,
+            y0=tl.lane_y,
+            x1=tl.x_end,
+            y1=tl.lane_y,
+            line={'color': tl.color, 'width': _TRACK_LINE_WIDTH},
+            opacity=0.5,
+            layer='below',
+        )
+
+
+def _add_single_geometry(fig: go.Figure, layout: ad.YardLayout) -> None:
+    """Single-column layout: one vertical throat with stacked lanes."""
+    y_lo, y_hi = layout.y_min - 0.6, layout.y_max + 0.6
+    fig.add_shape(
+        type='line',
+        x0=layout.throat_x,
+        y0=y_lo,
+        x1=layout.throat_x,
+        y1=y_hi,
+        line={'color': '#bdc3c7', 'width': 3, 'dash': 'dot'},
+        layer='below',
+    )
+    for tl in layout.tracks.values():
+        if tl.track_type == 'mainline':
+            fig.add_shape(
+                type='line',
+                x0=layout.throat_x,
+                y0=tl.lane_y,
+                x1=layout.x_max,
+                y1=tl.lane_y,
+                line={'color': tl.color, 'width': 9},
+                opacity=0.85,
+                layer='below',
+            )
+        else:
+            _track_line(fig, tl)
+        fig.add_annotation(
+            x=layout.throat_x - _LABEL_OFFSET_M,
+            y=tl.lane_y,
+            text=tl.track_id,
+            showarrow=False,
+            xanchor='right',
+            font={'size': 9, 'color': '#555'},
+        )
+
+
+def _add_zone_geometry(fig: go.Figure, layout: ad.YardLayout) -> None:
+    """Three-zone layout: local yard | Mainline corridor | remote storage."""
+    y_lo, y_hi = layout.y_min - 0.6, layout.y_max + 0.6
+    fig.add_shape(
+        type='rect',
+        x0=0,
+        y0=y_lo,
+        x1=layout.left_throat_x,
+        y1=y_hi,
+        fillcolor='#2980b9',
+        opacity=0.04,
+        line={'width': 0},
+        layer='below',
+    )
+    fig.add_shape(
+        type='rect',
+        x0=layout.right_throat_x,
+        y0=y_lo,
+        x1=layout.x_max,
+        y1=y_hi,
+        fillcolor='#8e44ad',
+        opacity=0.04,
+        line={'width': 0},
+        layer='below',
+    )
+    for ladder_x in (layout.left_throat_x, layout.right_throat_x):
+        fig.add_shape(
+            type='line',
+            x0=ladder_x,
+            y0=y_lo,
+            x1=ladder_x,
+            y1=y_hi,
+            line={'color': '#bdc3c7', 'width': 3, 'dash': 'dot'},
+            layer='below',
+        )
+    main_color = ad.TRACK_TYPE_COLORS['mainline']
+    fig.add_shape(
+        type='line',
+        x0=layout.left_throat_x,
+        y0=layout.corridor_y,
+        x1=layout.right_throat_x,
+        y1=layout.corridor_y,
+        line={'color': main_color, 'width': 9},
+        opacity=0.85,
+        layer='below',
+    )
+    for tl in layout.tracks.values():
+        if tl.track_type == 'mainline':
+            continue
+        _track_line(fig, tl)
+        if tl.zone == 'right':
+            label_x, anchor = tl.x_end + _LABEL_OFFSET_M, 'left'
+        else:
+            label_x, anchor = tl.x_start - _LABEL_OFFSET_M, 'right'
+        fig.add_annotation(
+            x=label_x, y=tl.lane_y, text=tl.track_id, showarrow=False, xanchor=anchor, font={'size': 9, 'color': '#555'}
+        )
+    _add_zone_titles(fig, layout)
+
+
+def _add_zone_titles(fig: go.Figure, layout: ad.YardLayout) -> None:
+    """Add the three zone headings below the layout."""
+    y = layout.corridor_y - 0.7
+    titles = [
+        (layout.left_throat_x / 2.0, 'Local retrofit yard', '#2471a3'),
+        ((layout.left_throat_x + layout.right_throat_x) / 2.0, '🚆 Main line', '#566573'),
+        ((layout.right_throat_x + layout.x_max) / 2.0, 'Arrival / remote storage', '#6c3483'),
+    ]
+    for x, text, color in titles:
+        fig.add_annotation(x=x, y=y, text=text, showarrow=False, font={'size': 11, 'color': color})
+
+
+def _draw_workshop(fig: go.Figure, tl: ad.TrackLayout) -> None:
+    """Draw a workshop as a labeled building box with one divider per bay."""
+    fig.add_shape(
+        type='rect',
+        x0=tl.x_start,
+        y0=tl.lane_y - _LANE_HALF_HEIGHT,
+        x1=tl.x_end,
+        y1=tl.lane_y + _LANE_HALF_HEIGHT,
+        line={'color': tl.color, 'width': 2},
+        fillcolor=tl.color,
+        opacity=0.18,
+        layer='below',
+    )
+    bays = tl.bays or 1
+    for i in range(1, bays):
+        x = tl.x_start + (tl.x_end - tl.x_start) * i / bays
+        fig.add_shape(
+            type='line',
+            x0=x,
+            y0=tl.lane_y - _LANE_HALF_HEIGHT,
+            x1=x,
+            y1=tl.lane_y + _LANE_HALF_HEIGHT,
+            line={'color': tl.color, 'width': 1, 'dash': 'dot'},
+            layer='below',
+        )
+    bay_label = f' · {tl.bays} bays' if tl.bays else ''
+    fig.add_annotation(
+        x=(tl.x_start + tl.x_end) / 2,
+        y=tl.lane_y + _LANE_HALF_HEIGHT,
+        text=f'🏭 {tl.track_id}{bay_label}',
+        showarrow=False,
+        yanchor='bottom',
+        font={'size': 9, 'color': '#1e5631'},
+    )
+
+
+def _animation_controls(
+    frames: list[ad.FrameData], frame_ms: int, active: int
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Build the play/pause buttons (updatemenus) and the time slider."""
+    play_args = {'frame': {'duration': frame_ms, 'redraw': True}, 'fromcurrent': True, 'transition': {'duration': 0}}
+    pause_args = {'frame': {'duration': 0, 'redraw': False}, 'mode': 'immediate', 'transition': {'duration': 0}}
+    slider_steps = [
+        {
+            'args': [
+                [str(i)],
+                {'frame': {'duration': 0, 'redraw': True}, 'mode': 'immediate', 'transition': {'duration': 0}},
+            ],
+            'label': f.datetime_label,
+            'method': 'animate',
+        }
+        for i, f in enumerate(frames)
+    ]
+    updatemenus = [
+        {
+            'type': 'buttons',
+            'direction': 'left',
+            'x': 0,
+            'y': -0.04,
+            'xanchor': 'left',
+            'yanchor': 'top',
+            'pad': {'r': 8, 't': 8},
+            'buttons': [
+                {'label': '▶ Play', 'method': 'animate', 'args': [None, play_args]},
+                {'label': '⏸ Pause', 'method': 'animate', 'args': [[None], pause_args]},
+            ],
+        }
+    ]
+    sliders = [
+        {
+            'active': active,
+            'x': 0.12,
+            'len': 0.88,
+            'xanchor': 'left',
+            'y': -0.04,
+            'yanchor': 'top',
+            'currentvalue': {'prefix': 'Time: ', 'font': {'size': 13}},
+            'pad': {'t': 8},
+            'steps': slider_steps,
+        }
+    ]
+    return updatemenus, sliders
+
+
+def _build_figure(
+    layout: ad.YardLayout, frames: list[ad.FrameData], frame_ms: int, show_labels: bool, active_frame: int = 0
+) -> go.Figure:
+    """Assemble the full animated Plotly figure, opened at ``active_frame``."""
+    active = max(0, min(active_frame, len(frames) - 1))
+    first = frames[active]
+    fig = go.Figure(data=[*_dynamic_traces(first, layout, show_labels), *_legend_traces()])
+    _add_static_geometry(fig, layout)
+
+    fig.frames = [
+        go.Frame(name=str(i), data=_dynamic_traces(f, layout, show_labels), traces=list(range(_DYNAMIC_TRACE_COUNT)))
+        for i, f in enumerate(frames)
+    ]
+
+    updatemenus, sliders = _animation_controls(frames, frame_ms, active)
+    fig.update_layout(
+        height=max(520, len(layout.tracks) * 28),
+        margin={'l': 10, 'r': 40, 't': 30, 'b': 10},
+        plot_bgcolor='white',
+        xaxis={'visible': False, 'range': [-_LABEL_OFFSET_M * 5, layout.x_max + _LABEL_OFFSET_M * 4]},
+        yaxis={'visible': False, 'range': [layout.y_min - 1.8, layout.y_max + 1.9]},
+        legend={'orientation': 'h', 'yanchor': 'bottom', 'y': 1.02, 'xanchor': 'left', 'x': 0},
+        updatemenus=updatemenus,
+        sliders=sliders,
+    )
+    return fig
+
+
+def _render_controls() -> tuple[int, int, float, bool]:
+    """Render the playback control widgets.
+
+    Returns ``(num_frames, length_s, speed, show_labels)``.
+    """
+    col1, col2, col3 = st.columns(3)
+    with col1:
+        num_frames = st.selectbox(
+            'Resolution (frames)',
+            options=_RESOLUTION_OPTIONS,
+            index=0,
+            help='More frames = smoother motion and finer stepping, but a larger figure. '
+            'The scale is quadratic, from 200 up to 10,000 frames.',
+        )
+    with col2:
+        anim_length_s = st.slider(
+            'Animation length (s)',
+            min_value=5,
+            max_value=120,
+            value=30,
+            step=5,
+            help='Wall-clock duration of one full playback.',
+        )
+    with col3:
+        speed = st.select_slider('Playback speed', options=[0.25, 0.5, 1.0, 2.0, 4.0], value=1.0)
+    show_labels = st.checkbox('Show wagon / locomotive ids on rectangles', value=False)
+    return num_frames, anim_length_s, speed, show_labels
+
+
+def _render_player(fig: go.Figure, num_frames: int) -> None:
+    """Embed the animated figure as HTML with client-side previous/next buttons.
+
+    Rendering through :func:`streamlit.components.v1.html` (instead of
+    ``st.plotly_chart``) lets the prev/next buttons call ``Plotly.animate`` in
+    the browser, so stepping never triggers a Streamlit rerun and stays in sync
+    with the native play/pause and slider.
+    """
+    plot_html = pio.to_html(
+        fig,
+        include_plotlyjs='cdn',
+        full_html=False,
+        auto_play=False,
+        div_id=_PLOT_DIV_ID,
+        config={
+            'responsive': True,
+            'displayModeBar': True,
+            'toImageButtonOptions': {'format': 'png', 'filename': 'yard_animation'},
+        },
+    )
+    controls = _CONTROLS_TEMPLATE.safe_substitute(div=_PLOT_DIV_ID, n=num_frames)
+    height = int(fig.layout.height or 520) + 70
+    components.html(f'<div class="yard-player">{plot_html}{controls}</div>', height=height, scrolling=False)
+
+
+def render_animation_tab(data: dict[str, Any]) -> None:  # pylint: disable=too-many-locals
+    """Render the animated simulation playback tab."""
+    st.header('🎬 Simulation Animation')
+    st.caption(
+        'Playback of wagon and locomotive movements through the yard. Resources are flat, '
+        'length-accurate rectangles: wagons blue until retrofitted then green, locomotives dark. '
+        'Wagons pack flush (no gap) and alternate shade so they stay countable. Live counters and '
+        'per-track capacity usage update as the clock advances.'
+    )
+
+    resource_locations = data.get('resource_locations')
+    resource_states = data.get('resource_states')
+    if resource_locations is None or resource_locations.empty:
+        st.warning('⚠️ No `resource_locations.csv` found for this scenario — cannot build the animation.')
+        return
+
+    scenario_config = data.get('scenario_config', {})
+    tracks_config = scenario_config.get('tracks', {}).get('tracks', [])
+    topology = scenario_config.get('topology', {})
+    workshops_config = scenario_config.get('workshops', {}).get('workshops', [])
+    lengths = ad.wagon_lengths(scenario_config.get('train_schedule'))
+    if not tracks_config:
+        st.warning('⚠️ No track configuration found — cannot build the yard layout.')
+        return
+
+    num_frames, anim_length_s, speed, show_labels = _render_controls()
+
+    with st.spinner('Preparing animation...'):
+        layout, frames = _compute_animation(
+            resource_locations,
+            resource_states,
+            {
+                'tracks': tracks_config,
+                'topology': topology,
+                'workshops': workshops_config,
+                'routes': scenario_config.get('routes'),
+                'wagon_lengths': lengths,
+            },
+            num_frames,
+            data.get('rejected_wagons'),
+            data.get('track_capacity'),
+        )
+
+    if not frames:
+        st.info('No movement data available to animate for this scenario.')
+        return
+
+    if num_frames >= _HEAVY_FRAME_COUNT:
+        st.warning(
+            f'⚠️ {num_frames:,} frames produces a large figure — playback and stepping may be sluggish '
+            'in the browser. Lower the resolution if it feels slow.'
+        )
+
+    frame_ms = max(_MIN_FRAME_MS, int(anim_length_s * 1000 / num_frames / speed))
+    fig = _build_figure(layout, frames, frame_ms, show_labels)
+    _render_player(fig, len(frames))
+    st.caption(
+        f'{len(frames)} frames · {len(layout.tracks)} tracks · x-axis in metres along track · '
+        f'press ▶ Play, drag the slider or use ⏮ / ⏭ to step a single frame, hover a rectangle for its id. '
+        f'(Loads Plotly from a CDN — needs internet on first paint.)'
+    )

--- a/popupsim/frontend/dashboard_components/routes_graph.py
+++ b/popupsim/frontend/dashboard_components/routes_graph.py
@@ -1,0 +1,114 @@
+"""Pure parsing of ``routes.json`` into a connectivity graph.
+
+``routes.json`` lists directed routes between tracks, each with an ordered
+``path`` (the tracks/edges traversed) and a ``duration``. This module turns that
+into:
+
+* an undirected adjacency map (track -> {neighbour: min duration}),
+* the subset of *direct* neighbours (hops that do not traverse the ``Mainline``),
+* a cluster classification of every track relative to the locomotive hub.
+
+No Streamlit / Plotly / pandas imports, so it stays trivially unit-testable.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections import deque
+from dataclasses import dataclass
+import itertools
+import math
+from typing import Any
+
+# The locomotive depot acts as the local hub; the Mainline is the long-haul
+# connector between the local yard and the arrival / remote-storage side.
+HUB_TRACK: str = 'track_19'
+MAINLINE: str = 'Mainline'
+
+# Cluster ranks drive top-to-bottom lane ordering (remote on top, Mainline as
+# the central spine, the local yard below).
+CLUSTER_RANK: dict[str, int] = {'remote': 0, 'mainline': 1, 'hub': 2, 'local': 2}
+
+
+@dataclass(frozen=True)
+class RouteGraph:
+    """Connectivity derived from ``routes.json``."""
+
+    adjacency: dict[str, dict[str, float]]
+    direct: dict[str, dict[str, float]]
+    cluster: dict[str, str]
+    track_ids: frozenset[str]
+    paths: dict[tuple[str, str], tuple[str, ...]]
+
+    def neighbours(self, track_id: str) -> dict[str, float]:
+        """Return the adjacency (neighbour -> min duration) for a track."""
+        return self.adjacency.get(track_id, {})
+
+
+def _add_edge(store: dict[str, dict[str, float]], a: str, b: str, duration: float) -> None:
+    """Add/relax an undirected edge with the minimum duration seen."""
+    store[a][b] = min(store[a].get(b, math.inf), duration)
+    store[b][a] = min(store[b].get(a, math.inf), duration)
+
+
+def _classify_clusters(direct: dict[str, dict[str, float]], track_ids: set[str]) -> dict[str, str]:
+    """Classify tracks as hub / local / remote / mainline.
+
+    ``local`` = reachable from :data:`HUB_TRACK` using only direct (non-Mainline)
+    hops; ``remote`` = everything else (only reachable across the Mainline).
+    """
+    local: set[str] = set()
+    if HUB_TRACK in track_ids:
+        queue: deque[str] = deque([HUB_TRACK])
+        local.add(HUB_TRACK)
+        while queue:
+            node = queue.popleft()
+            for neighbour in direct.get(node, {}):
+                if neighbour != MAINLINE and neighbour not in local:
+                    local.add(neighbour)
+                    queue.append(neighbour)
+
+    cluster: dict[str, str] = {}
+    for track_id in track_ids:
+        if track_id == MAINLINE:
+            cluster[track_id] = 'mainline'
+        elif track_id == HUB_TRACK:
+            cluster[track_id] = 'hub'
+        elif track_id in local:
+            cluster[track_id] = 'local'
+        else:
+            cluster[track_id] = 'remote'
+    return cluster
+
+
+def parse_routes(routes_json: dict[str, Any] | None) -> RouteGraph:
+    """Parse a ``routes.json`` payload into a :class:`RouteGraph`.
+
+    Returns an empty graph (all-local classification) when no routes are given.
+    """
+    routes = (routes_json or {}).get('routes', [])
+    adjacency: dict[str, dict[str, float]] = defaultdict(dict)
+    direct: dict[str, dict[str, float]] = defaultdict(dict)
+    paths: dict[tuple[str, str], tuple[str, ...]] = {}
+    track_ids: set[str] = set()
+
+    for route in routes:
+        path = [str(p) for p in route.get('path', []) if str(p)]
+        if len(path) < 2:
+            continue
+        duration = float(route.get('duration', 0.0))
+        track_ids.update(path)
+        paths[(path[0], path[-1])] = tuple(path)
+        for a, b in itertools.pairwise(path):
+            _add_edge(adjacency, a, b, duration)
+        if MAINLINE not in path:
+            _add_edge(direct, path[0], path[-1], duration)
+
+    cluster = _classify_clusters(direct, track_ids)
+    return RouteGraph(
+        adjacency={k: dict(v) for k, v in adjacency.items()},
+        direct={k: dict(v) for k, v in direct.items()},
+        cluster=cluster,
+        track_ids=frozenset(track_ids),
+        paths=paths,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,7 @@ warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
 files = ["popupsim/backend/src", "popupsim/backend/tests"]
-mypy_path = "popupsim/backend/src"
+mypy_path = "popupsim/backend/src:popupsim/frontend"
 namespace_packages = true
 explicit_package_bases = true
 show_column_numbers = true
@@ -211,11 +211,11 @@ disallow_incomplete_defs = false
 check_untyped_defs = true
 warn_return_any = false
 disable_error_code = [
-    "var-annotated", 
-    "call-arg", 
-    "union-attr", 
-    "assignment", 
-    "import-untyped", 
+    "var-annotated",
+    "call-arg",
+    "union-attr",
+    "assignment",
+    "import-untyped",
     "no-untyped-def",
     "misc",
     "func-returns-value",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,7 +242,7 @@ testpaths = ["popupsim/backend/tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-pythonpath = ["popupsim/backend/src"]
+pythonpath = ["popupsim/backend/src", "popupsim/frontend"]
 addopts = [
     "--strict-markers",
     "--strict-config",


### PR DESCRIPTION

Squashed from 

## Summary
This is a port of the visualization dashboard ot team-max from the Hack4Rail of 2026 in Vienna. Only the code and tests are ported. The simulation artefacts were removed.

The commits commits 30df94d, eb82471, 926993e, 9f28d9a, 2d75d95, b18f1f9 from the original repository (https://github.com/OpenRail-Playground/team-max/tree/animated-visualization-prototype) were squashed.

## Related Issues/Tickets

## Type of Change
- [x] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test improvement
- [ ] Other (please describe):

## How Has This Been Tested?
Running the test suite

## Checklist
- [ ] Follows conventional commit message format
- [ ] Code is formatted and linted (`uv run ruff format . && uv run ruff check .`)
- [ ] All tests pass (`uv run pytest`)
- [ ] Documentation updated (if needed)

## Additional Notes

