### PR TITLE
refactor(backend): clean up optimizer and fix lint/type/format debt

### DIFF
--- a/popupsim/backend/src/contexts/retrofit_workflow/application/coordinators/workshop_coordinator.py
+++ b/popupsim/backend/src/contexts/retrofit_workflow/application/coordinators/workshop_coordinator.py
@@ -257,7 +257,8 @@ class WorkshopCoordinator:  # pylint: disable=too-many-instance-attributes,too-f
                 _ = self.batch_service.create_batch_aggregate(wagons, retrofitted_track_id)
                 yield from self._transport_from_workshop(pickup_loco, workshop_id, wagons)
                 transport_completed = True
-            except GeneratorExit:
+            # Re-raise GeneratorExit so it is not swallowed by the broad fallback below.
+            except GeneratorExit:  # pylint: disable=try-except-raise
                 raise
             except Exception:  # pylint: disable=broad-exception-caught
                 yield from self._transport_from_workshop(pickup_loco, workshop_id, wagons)
@@ -327,7 +328,8 @@ class WorkshopCoordinator:  # pylint: disable=too-many-instance-attributes,too-f
             _ = self.batch_service.create_batch_aggregate(wagons, workshop_id)
             # Batch aggregate created successfully - rake is valid
             yield from self._transport_to_workshop(loco, workshop_id, wagons, retrofit_track_id)
-        except GeneratorExit:
+        # Re-raise GeneratorExit so it is not swallowed by the broad fallback below.
+        except GeneratorExit:  # pylint: disable=try-except-raise
             raise
         except Exception:  # pylint: disable=broad-exception-caught
             # Fallback to old method
@@ -774,7 +776,8 @@ class WorkshopCoordinator:  # pylint: disable=too-many-instance-attributes,too-f
             _ = self.batch_service.create_batch_aggregate(wagons, 'retrofitted')
             yield from self._transport_from_workshop(pickup_loco, workshop_id, wagons)
             transport_completed = True
-        except GeneratorExit:
+        # Re-raise GeneratorExit so it is not swallowed by the broad fallback below.
+        except GeneratorExit:  # pylint: disable=try-except-raise
             raise
         except Exception:  # pylint: disable=broad-exception-caught
             yield from self._transport_from_workshop(pickup_loco, workshop_id, wagons)

--- a/popupsim/backend/src/contexts/retrofit_workflow/application/event_collector.py
+++ b/popupsim/backend/src/contexts/retrofit_workflow/application/event_collector.py
@@ -5,8 +5,6 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from collections.abc import Callable
-
 from contexts.retrofit_workflow.application.services.dual_stream_adapter import _record_loco_dual_stream
 from contexts.retrofit_workflow.application.services.dual_stream_adapter import _record_wagon_dual_stream
 from contexts.retrofit_workflow.application.services.dual_stream_collector import DualStreamEventCollector

--- a/popupsim/backend/src/contexts/retrofit_workflow/application/services/metrics_aggregator.py
+++ b/popupsim/backend/src/contexts/retrofit_workflow/application/services/metrics_aggregator.py
@@ -57,9 +57,7 @@ class MetricsAggregator:
         unique_rejected_no_retrofit = {
             e.wagon_id for e in rejected if e.rejection_reason and 'No Retrofit' in e.rejection_reason
         } - unique_retrofitted  # Exclude wagons that were actually retrofitted
-        unique_rejected_loaded = {
-            e.wagon_id for e in rejected if e.rejection_reason and 'Loaded' in e.rejection_reason
-        }
+        unique_rejected_loaded = {e.wagon_id for e in rejected if e.rejection_reason and 'Loaded' in e.rejection_reason}
 
         # Event counts for display (may include duplicates from re-arrivals)
         rejected_no_retrofit = len([e for e in rejected if e.rejection_reason and 'No Retrofit' in e.rejection_reason])

--- a/popupsim/backend/src/main.py
+++ b/popupsim/backend/src/main.py
@@ -4,19 +4,21 @@ from dataclasses import dataclass
 import json
 import logging
 from logging import StreamHandler
-import os
 from pathlib import Path
 import shutil
+from typing import TYPE_CHECKING
 from typing import Annotated
 from typing import Any
 
 from application.simulation_service import SimulationApplicationService
 from contexts.configuration.domain.configuration_builder import ConfigurationBuilder
-from contexts.configuration.domain.models.scenario import Scenario
 from contexts.external_trains.application.external_trains_context import ExternalTrainsContext
 from infrastructure.logging import init_process_logger
 from shared.infrastructure.simpy_time_converters import timedelta_to_sim_ticks
 import typer
+
+if TYPE_CHECKING:
+    from optimizer.search import OptimizationResult
 
 app = typer.Typer(name='popupsim-new', help='PopUpSim New Architecture - Bounded contexts')
 
@@ -205,250 +207,86 @@ def run(
     typer.echo(f'\nSIMULATION TIME:            {result.duration:.1f} minutes')
     typer.echo('=' * 60)
 
+
 @app.command()
-def optimize(
+# Each parameter below is a distinct CLI option, so the argument count is intentional.
+def optimize(  # noqa: PLR0913  # pylint: disable=too-many-arguments,too-many-positional-arguments
     scenario_folder_path: Annotated[Path, typer.Option('--scenario', help='Path to scenario directory')],
     seed: Annotated[int, typer.Option('--seed', help='Random seed')] = 42,
     n_random: Annotated[int, typer.Option('--n-random', help='Number of random samples')] = 500,
     n_workers: Annotated[int, typer.Option('--n-workers', help='Number of parallel workers')] = 10,
     k_starts: Annotated[int, typer.Option('--k-starts', help='Number of top elites to start Phase 2 descent from')] = 5,
     max_rounds: Annotated[int, typer.Option('--max-rounds', help='Maximum rounds of coordinate descent')] = 5,
-    weight_completion: Annotated[float, typer.Option('--weight-completion', help='Weight for completion rate in score calculation')] = 0.9,
-    weight_loco: Annotated[float, typer.Option('--weight-loco', help='Weight for locomotive utilization in score calculation')] = -0.1,
-    results_json: Annotated[Path, typer.Option('--results-json', help='Path to output JSON file')] = Path('optimization_results.json'),
+    weight_completion: Annotated[
+        float, typer.Option('--weight-completion', help='Weight for completion rate in score calculation')
+    ] = 0.9,
+    weight_loco: Annotated[
+        float, typer.Option('--weight-loco', help='Weight for locomotive utilization in score calculation')
+    ] = -0.1,
+    results_json: Annotated[Path, typer.Option('--results-json', help='Path to output JSON file')] = Path(
+        'optimization_results.json'
+    ),
 ) -> None:
     """Load and optimize a scenario using a two-phase adaptive coordinate search."""
-    import random
-    import copy
-    import json
-    from tqdm import trange
-    from optimizer.harness import run_simulation, run_parallel
-    from optimizer.problem_space import parameter_config
-    from optimizer.util import score, convert, get_neighbors
-    
-    scenario = Scenario.model_validate_json((scenario_folder_path / "scenario.json").read_text(encoding='utf-8'))
-    initial_result = run_simulation(scenario_folder_path, weight_completion=weight_completion, weight_loco=weight_loco)
-    initial_summary = initial_result[0]
-    initial_score = initial_result[1]
+    # Imported here to avoid a circular import: optimizer.harness imports `run`
+    # from this module, so importing optimizer.search at module load would be cyclic.
+    from optimizer.search import SearchConfig  # pylint: disable=import-outside-toplevel
+    from optimizer.search import optimize_scenario  # pylint: disable=import-outside-toplevel
+    from optimizer.search import write_results  # pylint: disable=import-outside-toplevel
 
-    # Helper function to canonicalize parameter dicts for caching seen configurations
-    def dict_to_key(d: dict) -> str:
-        def _serialize_enums(obj):
-            if isinstance(obj, dict):
-                return {k: _serialize_enums(v) for k, v in obj.items()}
-            elif isinstance(obj, list):
-                return [_serialize_enums(x) for x in obj]
-            elif hasattr(obj, "value"):
-                return obj.value
-            return obj
-        return json.dumps(_serialize_enums(d), sort_keys=True)
-
-    # Initialize seen evaluations to avoid duplicates and store initial config
-    seen = {}
-    initial_params = {
-        "task_priorities": {
-            k: (v.model_dump() if v is not None else None)
-            for k, v in scenario.task_priorities.items()
-        }
-    }
-    initial_key = dict_to_key(initial_params)
-    seen[initial_key] = {
-        "score": initial_score,
-        "completion_rate_pct": initial_summary.completion_rate_pct,
-        "loco_utilization_pct": initial_summary.loco_utilization_pct,
-        "params": initial_params,
-    }
-
-    print(parameter_config.size())
-
-    # 1. Phase: Randomly generate parameters.
-    rng = random.Random(seed)
-    samples = []
-    elite_scenarios = []
-    attempts = 0
-    while len(samples) < n_random and attempts < n_random * 10:
-        attempts += 1
-        test = parameter_config.sample_value(rng)
-        if test is None:
-            raise RuntimeError("Failed to sample parameters. Top-Level Parameters should not contain Optionals.")
-        key = dict_to_key(test)
-        if key in seen or any(dict_to_key(s) == key for s in samples):
-            continue
-        new_scenario = convert(test, scenario)
-        samples.append(test)
-        elite_scenarios.append(new_scenario)
-
-    typer.echo("Evaluating initial random sample pool in parallel...")
-    results = run_parallel(scenario_folder_path, elite_scenarios, weight_completion=weight_completion, weight_loco=weight_loco)
-    
-    rated_runs = []
-    for param_dict, res in zip(samples, results):
-        if res is not None:
-            summary, sc, scen = res
-            rated_runs.append((sc, param_dict, res))
-            
-    rated_runs.sort(key=lambda x: x[0], reverse=True)
-
-    # Print top 5 elites
-    for i in range(min(5, len(rated_runs))):
-        sc, param_dict, res = rated_runs[i]
-        result = res[0]
-        typer.echo(f"Top {i+1} Elite: Score = {sc:.4f}, Completion Rate = {result.completion_rate_pct:.1f}%, Loco Utilization = {result.loco_utilization_pct:.1f}%")
-
-    # Cache Phase 1 evaluations
-    for sc, param_dict, res in rated_runs:
-        summary = res[0]
-        seen[dict_to_key(param_dict)] = {
-            "score": sc,
-            "completion_rate_pct": summary.completion_rate_pct,
-            "loco_utilization_pct": summary.loco_utilization_pct,
-            "params": param_dict,
-        }
-
-    # 2. Phase: Coordinate descent search along elites.
-    starts = rated_runs[:k_starts]
-    _TASK_NAMES = (
-        "collection_to_retrofit",
-        "retrofit_to_workshop",
-        "workshop_to_retrofitted",
-        "retrofitted_to_parking",
+    config = SearchConfig(
+        seed=seed,
+        n_random=n_random,
+        k_starts=k_starts,
+        max_rounds=max_rounds,
+        weight_completion=weight_completion,
+        weight_loco=weight_loco,
+        n_workers=n_workers,
     )
 
-    typer.echo(f"\nPhase 2 — coordinate descent from {len(starts)} starting point(s)")
+    typer.echo('Running two-phase optimization (random search + coordinate descent)...')
+    result = optimize_scenario(scenario_folder_path, config)
 
-    for start_idx, (start_score, start_params, start_res) in enumerate(starts):
-        current_params = start_params
-        current_score = start_score
-        typer.echo(f"\n  Start {start_idx + 1}/{len(starts)}  (initial score={current_score:.4f})")
+    write_results(result, results_json)
+    _print_optimization_summary(result, len(result.records))
 
-        for round_idx in range(max_rounds):
-            improved = False
 
-            for task_name in _TASK_NAMES:
-                task_param = parameter_config.params["task_priorities"].params[task_name]
-                task_val = current_params["task_priorities"][task_name]
-                
-                neighbors_task_val = get_neighbors(task_param, task_val)
-                
-                neighbor_params = []
-                neighbor_scenarios = []
-                
-                for task_neighbor in neighbors_task_val:
-                    n_params = copy.deepcopy(current_params)
-                    n_params["task_priorities"][task_name] = task_neighbor
-                    
-                    key = dict_to_key(n_params)
-                    if key not in seen:
-                        neighbor_params.append(n_params)
-                        neighbor_scenarios.append(convert(n_params, scenario))
+def _format_diff(value: float, initial_value: float, is_pct: bool = False) -> str:
+    """Format the signed difference of ``value`` from ``initial_value`` for display."""
+    diff = value - initial_value
+    if abs(diff) < 1e-9:
+        diff = 0.0
+    sign = '+' if diff >= 0 else ''
+    if is_pct:
+        return f' ({sign}{diff:.2f}%)'
+    return f' ({sign}{diff:.4f})'
 
-                if neighbor_scenarios:
-                    # Run neighbor batch in parallel
-                    batch_results = run_parallel(scenario_folder_path, neighbor_scenarios, weight_completion=weight_completion, weight_loco=weight_loco)
-                    for n_p, res in zip(neighbor_params, batch_results):
-                        if res is not None:
-                            summary, sc, scen = res
-                            seen[dict_to_key(n_p)] = {
-                                "score": sc,
-                                "completion_rate_pct": summary.completion_rate_pct,
-                                "loco_utilization_pct": summary.loco_utilization_pct,
-                                "params": n_p,
-                            }
 
-                # Find the best neighbor (including previously evaluated configurations)
-                best_neighbor = None
-                best_neighbor_score = current_score
-                
-                for task_neighbor in neighbors_task_val:
-                    n_params = copy.deepcopy(current_params)
-                    n_params["task_priorities"][task_name] = task_neighbor
-                    key = dict_to_key(n_params)
-                    s = seen.get(key, {}).get("score", float("-inf"))
-                    if s > best_neighbor_score:
-                        best_neighbor_score = s
-                        best_neighbor = n_params
+def _print_optimization_summary(result: 'OptimizationResult', total_evaluated: int) -> None:
+    """Print the initial configuration and the top optimized configurations."""
+    initial = result.initial
+    ranked = result.ranked()
 
-                if best_neighbor is not None:
-                    typer.echo(
-                        f"    [{task_name[:3]}] improved: "
-                        f"{current_score:.4f} → {best_neighbor_score:.4f}"
-                    )
-                    current_params = best_neighbor
-                    current_score = best_neighbor_score
-                    improved = True
+    typer.echo('\n' + '=' * 60)
+    typer.echo(f'OPTIMIZATION COMPLETE (Total unique configurations evaluated: {total_evaluated})')
+    typer.echo('=' * 60)
 
-            if not improved:
-                typer.echo(f"  Converged after round {round_idx + 1}")
-                break
-        else:
-            typer.echo(f"  Reached max_rounds={max_rounds}")
-
-        typer.echo(f"  Final score for start {start_idx + 1}: {current_score:.4f}")
-
-    # Output overall results
-    sorted_seen = sorted(seen.values(), key=lambda x: x["score"], reverse=True)
-
-    def serialize_params(obj):
-        if isinstance(obj, dict):
-            return {k: serialize_params(v) for k, v in obj.items()}
-        elif isinstance(obj, list):
-            return [serialize_params(x) for x in obj]
-        elif hasattr(obj, "value"):
-            return obj.value
-        return obj
-
-    results_list = [
-        {
-            "parameters": serialize_params(r["params"]),
-            "completion": r["completion_rate_pct"],
-            "loco_utilization": r["loco_utilization_pct"],
-            "score": r["score"],
-        }
-        for r in sorted_seen
-    ]
-
-    results_json.parent.mkdir(parents=True, exist_ok=True)
-    with open(results_json, "w", encoding="utf-8") as f:
-        json.dump(results_list, f, indent=2)
-
-    typer.echo("\n" + "=" * 60)
-    typer.echo(f"OPTIMIZATION COMPLETE (Total unique configurations evaluated: {len(seen)})")
-    typer.echo("=" * 60)
-
-    # Helper function to format the difference compared to initial
-    def format_diff(val: float, initial_val: float, is_pct: bool = False) -> str:
-        diff = val - initial_val
-        if abs(diff) < 1e-9:
-            diff = 0.0
-        sign = "+" if diff >= 0 else ""
-        pct_sign = "%" if is_pct else ""
-        if is_pct:
-            return f" ({sign}{diff:.2f}{pct_sign})"
-        else:
-            return f" ({sign}{diff:.4f})"
-
-    typer.echo("\nInitial Configuration:")
+    typer.echo('\nInitial Configuration:')
     typer.echo(
-        f"  Score = {initial_score:.4f} | "
-        f"Completion Rate = {initial_summary.completion_rate_pct:.2f}% | "
-        f"Loco Utilization = {initial_summary.loco_utilization_pct:.2f}%"
+        f'  Score = {initial.score:.4f} | '
+        f'Completion Rate = {initial.completion_rate_pct:.2f}% | '
+        f'Loco Utilization = {initial.loco_utilization_pct:.2f}%'
     )
 
-    typer.echo("\nTop 5 Overall Optimized Configurations:")
-    for i in range(min(5, len(sorted_seen))):
-        r = sorted_seen[i]
-        sc = r["score"]
-        comp = r["completion_rate_pct"]
-        loco = r["loco_utilization_pct"]
-        
-        score_diff = format_diff(sc, initial_score, is_pct=False)
-        comp_diff = format_diff(comp, initial_summary.completion_rate_pct, is_pct=True)
-        loco_diff = format_diff(loco, initial_summary.loco_utilization_pct, is_pct=True)
-        
+    typer.echo('\nTop 5 Overall Optimized Configurations:')
+    for rank, record in enumerate(ranked[:5], start=1):
+        score_diff = _format_diff(record.score, initial.score)
+        comp_diff = _format_diff(record.completion_rate_pct, initial.completion_rate_pct, is_pct=True)
+        loco_diff = _format_diff(record.loco_utilization_pct, initial.loco_utilization_pct, is_pct=True)
         typer.echo(
-            f"  Rank {i+1}: Score = {sc:.4f}{score_diff} | "
-            f"Completion Rate = {comp:.2f}%{comp_diff} | "
-            f"Loco Utilization = {loco:.2f}%{loco_diff}"
+            f'  Rank {rank}: Score = {record.score:.4f}{score_diff} | '
+            f'Completion Rate = {record.completion_rate_pct:.2f}%{comp_diff} | '
+            f'Loco Utilization = {record.loco_utilization_pct:.2f}%{loco_diff}'
         )
 
 

--- a/popupsim/backend/src/optimizer/__init__.py
+++ b/popupsim/backend/src/optimizer/__init__.py
@@ -1,0 +1,1 @@
+"""Scenario parameter optimizer for the retrofit simulation."""

--- a/popupsim/backend/src/optimizer/harness.py
+++ b/popupsim/backend/src/optimizer/harness.py
@@ -1,25 +1,36 @@
+"""Simulation execution harness for the optimizer (single and parallel runs)."""
+
+from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import as_completed
 import contextlib
 import io
 import logging
-import shutil
-import tempfile
+import os
 from pathlib import Path
+import shutil
+import sys
+import tempfile
 
 from contexts.configuration.domain.models.scenario import Scenario
 from main import run
 from optimizer.summary_model import SummaryMetrics
 from optimizer.util import score
 
+try:
+    from tqdm import tqdm
 
+    _HAS_TQDM = True
+except ImportError:
+    _HAS_TQDM = False
 
 type ScenarioResult = tuple[SummaryMetrics, float, Scenario]
+type ScenarioTask = tuple[Path, Scenario, float, float]
+
 
 def run_simulation(
-    scenario_dir: Path,
-    scenario: Scenario | None = None,
-    weight_completion: float = 0.9,
-    weight_loco: float = -0.1
+    scenario_dir: Path, scenario: Scenario | None = None, weight_completion: float = 0.9, weight_loco: float = -0.1
 ) -> ScenarioResult:
+    """Run a single simulation and return its summary, score and resolved scenario."""
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
         output_tmp = tmp_path / 'output'
@@ -29,8 +40,7 @@ def run_simulation(
             shutil.copytree(scenario_dir, scenario_path)
             exclude_fields = {'tracks', 'workshops', 'locomotives', 'trains', 'topology', 'process_times'}
             (scenario_path / 'scenario.json').write_text(
-                scenario.model_dump_json(indent=2, exclude=exclude_fields),
-                encoding='utf-8'
+                scenario.model_dump_json(indent=2, exclude=exclude_fields), encoding='utf-8'
             )
         else:
             scenario_path = scenario_dir
@@ -49,19 +59,19 @@ def run_simulation(
         summary_file = output_tmp / 'summary_metrics.json'
         if not summary_file.exists():
             raise RuntimeError(f'summary_metrics.json not found in {output_tmp}')
-        
+
         summary = SummaryMetrics.model_validate_json(summary_file.read_text(encoding='utf-8'))
-        
+
         if scenario is None:
             scenario = Scenario.model_validate_json((scenario_path / 'scenario.json').read_text(encoding='utf-8'))
-            
+
         return (summary, score(summary, weight_completion, weight_loco), scenario)
 
-def _run_single_scenario(args: tuple[Path, Scenario, float, float]) -> ScenarioResult:
-    import sys
-    from pathlib import Path
-    
-    # Ensure the backend src directory is in sys.path for worker subprocess imports
+
+def _run_single_scenario(args: ScenarioTask) -> ScenarioResult:
+    """Worker entry point: ensure the src dir is importable, then run one simulation."""
+    # Worker subprocesses start with a fresh interpreter, so the backend src
+    # directory must be re-added to sys.path before optimizer imports resolve.
     src_dir = str(Path(__file__).resolve().parent.parent)
     if src_dir not in sys.path:
         sys.path.insert(0, src_dir)
@@ -74,35 +84,20 @@ def run_parallel(
     scenario_dir: Path,
     scenarios: list[Scenario],
     weight_completion: float = 0.9,
-    weight_loco: float = -0.1
-) -> list[ScenarioResult]:
-    import os
-    from concurrent.futures import ProcessPoolExecutor, as_completed
-
-    try:
-        from tqdm import tqdm
-        has_tqdm = True
-    except ImportError:
-        has_tqdm = False
-
-    max_workers = os.cpu_count() or 1
-    tasks = [(scenario_dir, scenario, weight_completion, weight_loco) for scenario in scenarios]
+    weight_loco: float = -0.1,
+    max_workers: int | None = None,
+) -> list[ScenarioResult | None]:
+    """Run simulations for many scenarios in parallel, preserving input order."""
+    workers = max_workers if max_workers and max_workers > 0 else (os.cpu_count() or 1)
+    tasks: list[ScenarioTask] = [(scenario_dir, scenario, weight_completion, weight_loco) for scenario in scenarios]
     results: list[ScenarioResult | None] = [None] * len(scenarios)
 
-    with ProcessPoolExecutor(max_workers=max_workers) as executor:
-        futures = {
-            executor.submit(_run_single_scenario, task): i
-            for i, task in enumerate(tasks)
-        }
+    with ProcessPoolExecutor(max_workers=workers) as executor:
+        futures = {executor.submit(_run_single_scenario, task): i for i, task in enumerate(tasks)}
+        completed = as_completed(futures)
+        if _HAS_TQDM:
+            completed = tqdm(completed, total=len(futures), desc='Running scenarios in parallel')
+        for future in completed:
+            results[futures[future]] = future.result()
 
-        if has_tqdm:
-            for future in tqdm(as_completed(futures), total=len(futures), desc="Running scenarios in parallel"):
-                idx = futures[future]
-                results[idx] = future.result()
-        else:
-            for future in as_completed(futures):
-                idx = futures[future]
-                results[idx] = future.result()
-
-    return results  # type: ignore
-        
+    return results

--- a/popupsim/backend/src/optimizer/parameter_model.py
+++ b/popupsim/backend/src/optimizer/parameter_model.py
@@ -1,66 +1,76 @@
-from abc import ABC, abstractmethod
-import random
-from typing import Any, Generic, Iterator, TypeVar
+"""Parameter model describing the optimizer search space and value enumeration."""
+
+from abc import ABC
+from abc import abstractmethod
+from collections.abc import Iterator
 from dataclasses import dataclass
 from itertools import product
+import random
+from typing import Any
 
-T = TypeVar("T")
 
-class Parameter(ABC, Generic[T]):
+class Parameter[T](ABC):
+    """Abstract search-space parameter that can enumerate and sample its values."""
 
     @abstractmethod
     def iter_values(self) -> Iterator[T]:
         """Enumerate all discrete values. Raises if purely continuous."""
-        ...
 
     @abstractmethod
     def sample_value(self, rng: random.Random) -> T:
         """Draw one value uniformly at random."""
-        ...
 
     @abstractmethod
     def size(self) -> int:
-        """Number of distinct values."""
-        ...
+        """Return the number of distinct values."""
+
 
 @dataclass(frozen=True)
-class DiscreteParameter(Parameter[T]):
+class DiscreteParameter[T](Parameter[T]):
+    """Parameter with a fixed tuple of candidate values."""
 
     values: tuple[T, ...]
 
     def iter_values(self) -> Iterator[T]:
+        """Yield each candidate value."""
         yield from self.values
 
     def sample_value(self, rng: random.Random) -> T:
+        """Return a randomly chosen candidate value."""
         return rng.choice(self.values)
 
     def size(self) -> int:
+        """Return the number of candidate values."""
         return len(self.values)
+
 
 @dataclass(frozen=True)
 class ContinuousParameter(Parameter[float]):
+    """Parameter over a continuous range discretised by a fixed step size."""
+
     low: float
     high: float
     step_size: float
 
     def iter_values(self) -> Iterator[float]:
-        size = self.size()
-        if size is None:
-            raise NotImplementedError("ContinuousParameter without steps cannot be enumerated.")
-        for i in range(size):
+        """Yield each discrete value across the range."""
+        for i in range(self.size()):
             yield self.low + i * self.step_size
 
     def sample_value(self, rng: random.Random) -> float:
+        """Return a uniformly sampled value within the range."""
         return rng.uniform(self.low, self.high)
 
     def size(self) -> int:
+        """Return the number of discrete steps across the range."""
         return int((self.high - self.low) / self.step_size) + 1
-    
+
+
 def _make_canonical(val: Any) -> Any:
     """Recursively convert unhashable types (dicts, lists) into hashable counterparts (tuples)."""
     if isinstance(val, dict):
         return tuple(sorted((k, _make_canonical(v)) for k, v in val.items()))
-    elif isinstance(val, (list, tuple)):
+    if isinstance(val, (list, tuple)):
         return tuple(_make_canonical(x) for x in val)
     return val
 
@@ -68,23 +78,26 @@ def _make_canonical(val: Any) -> Any:
 def _safe_sort_key(val: Any) -> Any:
     """Generate a sort key for canonicalized values to ensure deterministic sorting of mixed types."""
     if val is None:
-        return (0, "")
+        return (0, '')
     if isinstance(val, (bool, int, float)):
         return (1, float(val))
     if isinstance(val, str):
         return (2, val)
     if isinstance(val, tuple):
         return (3, tuple(_safe_sort_key(x) for x in val))
-    if hasattr(val, "value"):
+    if hasattr(val, 'value'):
         return (4, _safe_sort_key(val.value))
     return (5, str(val))
 
 
 @dataclass(frozen=True)
 class ListParameter(Parameter[list[Any]]):
+    """Parameter representing a set of optional slots combined into a list."""
+
     slots: tuple[Parameter[Any], ...]
 
     def iter_values(self) -> Iterator[list[Any]]:
+        """Yield each unique list combination across the slots."""
         # Pre-canonicalize all values for each slot to avoid repeating in the Cartesian product
         canonical_slots = []
         for slot in self.slots:
@@ -109,42 +122,49 @@ class ListParameter(Parameter[list[Any]]):
                 yield [item[2] for item in filtered]
 
     def sample_value(self, rng: random.Random) -> list[Any]:
+        """Return a randomly sampled list combination across the slots."""
         combo = [slot.sample_value(rng) for slot in self.slots]
         canonical_elements = [(_make_canonical(x), x) for x in combo if x is not None]
         canonical_elements.sort(key=lambda item: _safe_sort_key(item[0]))
         return [item[1] for item in canonical_elements]
 
     def size(self) -> int:
+        """Return the number of unique list combinations."""
         return sum(1 for _ in self.iter_values())
 
     @classmethod
-    def repeat(cls, slot: Parameter[Any], max_count: int) -> "ListParameter":
+    def repeat(cls, slot: Parameter[Any], max_count: int) -> 'ListParameter':
+        """Return a ListParameter with ``slot`` repeated ``max_count`` times."""
         return cls(slots=tuple(slot for _ in range(max_count)))
 
-    
+
 @dataclass
 class GroupParameter(Parameter[dict[str, Any] | None]):
+    """Parameter grouping named sub-parameters into an optional mapping."""
+
     params: dict[str, Parameter[Any]]
     optional: bool = True
 
     def _sub_size(self) -> int:
         total = 1
         for p in self.params.values():
-            s = p.size()
-            total *= s
+            total *= p.size()
         return total
 
     def iter_values(self) -> Iterator[dict[str, Any] | None]:
+        """Yield each mapping combination of the grouped sub-parameters."""
         if self.optional:
             yield None
         keys = list(self.params.keys())
         for combo in product(*(self.params[k].iter_values() for k in keys)):
-            yield dict(zip(keys, combo))
+            yield dict(zip(keys, combo, strict=True))
 
     def sample_value(self, rng: random.Random) -> dict[str, Any] | None:
+        """Return a randomly sampled mapping of the grouped sub-parameters."""
         if self.optional and rng.random() < 1.0 / (self._sub_size() + 1):
             return None
         return {k: p.sample_value(rng) for k, p in self.params.items()}
 
     def size(self) -> int:
+        """Return the number of mapping combinations."""
         return sum(1 for _ in self.iter_values())

--- a/popupsim/backend/src/optimizer/problem_space.py
+++ b/popupsim/backend/src/optimizer/problem_space.py
@@ -1,33 +1,37 @@
-from shared.domain.value_objects.selection_strategy import SelectionStrategy
+"""Search-space definition of tunable scenario parameters for the optimizer."""
+
 from contexts.retrofit_workflow.domain.value_objects.task_priority import PriorityConditionType
-from optimizer.parameter_model import DiscreteParameter, GroupParameter, ListParameter
+from optimizer.parameter_model import DiscreteParameter
+from optimizer.parameter_model import GroupParameter
+from optimizer.parameter_model import ListParameter
+from shared.domain.value_objects.selection_strategy import SelectionStrategy
 
 collection_to_retrofit_parameter = GroupParameter(
     params={
-        "base_priority": DiscreteParameter((1, 2, 3)),
-        "hold_until": GroupParameter(
+        'base_priority': DiscreteParameter((1, 2, 3)),
+        'hold_until': GroupParameter(
             params={
-                "condition": DiscreteParameter((PriorityConditionType.TARGET_FILL_BELOW,)),
-                "threshold": DiscreteParameter((0.7, 0.85)),
+                'condition': DiscreteParameter((PriorityConditionType.TARGET_FILL_BELOW,)),
+                'threshold': DiscreteParameter((0.7, 0.85)),
             },
             optional=True,
         ),
-        "max_hold_time": DiscreteParameter((None, 30.0)),
-        "rules": ListParameter(
+        'max_hold_time': DiscreteParameter((None, 30.0)),
+        'rules': ListParameter(
             slots=(
                 GroupParameter(
                     params={
-                        "condition": DiscreteParameter((PriorityConditionType.SOURCE_FILL_ABOVE,)),
-                        "threshold": DiscreteParameter((0.4, 0.7)),
-                        "priority": DiscreteParameter((1,)),
+                        'condition': DiscreteParameter((PriorityConditionType.SOURCE_FILL_ABOVE,)),
+                        'threshold': DiscreteParameter((0.4, 0.7)),
+                        'priority': DiscreteParameter((1,)),
                     },
                     optional=True,
                 ),
                 GroupParameter(
                     params={
-                        "condition": DiscreteParameter((PriorityConditionType.SOURCE_FILL_ABOVE,)),
-                        "threshold": DiscreteParameter((0.7, 0.9)),
-                        "priority": DiscreteParameter((0,)),
+                        'condition': DiscreteParameter((PriorityConditionType.SOURCE_FILL_ABOVE,)),
+                        'threshold': DiscreteParameter((0.7, 0.9)),
+                        'priority': DiscreteParameter((0,)),
                     },
                     optional=True,
                 ),
@@ -39,22 +43,22 @@ collection_to_retrofit_parameter = GroupParameter(
 
 retrofit_to_workshop_parameter = GroupParameter(
     params={
-        "base_priority": DiscreteParameter((2, 3)),
-        "rules": ListParameter(
+        'base_priority': DiscreteParameter((2, 3)),
+        'rules': ListParameter(
             slots=(
                 GroupParameter(
                     params={
-                        "condition": DiscreteParameter((PriorityConditionType.TARGET_IDLE,)),
-                        "threshold": DiscreteParameter((0.0,)),
-                        "priority": DiscreteParameter((0,)),
+                        'condition': DiscreteParameter((PriorityConditionType.TARGET_IDLE,)),
+                        'threshold': DiscreteParameter((0.0,)),
+                        'priority': DiscreteParameter((0,)),
                     },
                     optional=True,
                 ),
                 GroupParameter(
                     params={
-                        "condition": DiscreteParameter((PriorityConditionType.SOURCE_FILL_BELOW,)),
-                        "threshold": DiscreteParameter((0.1, 0.2)),
-                        "priority": DiscreteParameter((5,)),
+                        'condition': DiscreteParameter((PriorityConditionType.SOURCE_FILL_BELOW,)),
+                        'threshold': DiscreteParameter((0.1, 0.2)),
+                        'priority': DiscreteParameter((5,)),
                     },
                     optional=True,
                 ),
@@ -66,37 +70,37 @@ retrofit_to_workshop_parameter = GroupParameter(
 
 workshop_to_retrofitted_parameter = GroupParameter(
     params={
-        "base_priority": DiscreteParameter((1, 2)),
+        'base_priority': DiscreteParameter((1, 2)),
     },
     optional=True,
 )
 
 retrofitted_to_parking_parameter = GroupParameter(
     params={
-        "base_priority": DiscreteParameter((2, 3)),
-        "hold_until": GroupParameter(
+        'base_priority': DiscreteParameter((2, 3)),
+        'hold_until': GroupParameter(
             params={
-                "condition": DiscreteParameter((PriorityConditionType.SOURCE_FILL_ABOVE,)),
-                "threshold": DiscreteParameter((0.15, 0.35)),
+                'condition': DiscreteParameter((PriorityConditionType.SOURCE_FILL_ABOVE,)),
+                'threshold': DiscreteParameter((0.15, 0.35)),
             },
             optional=True,
         ),
-        "max_hold_time": DiscreteParameter((None, 45.0)),
-        "rules": ListParameter(
+        'max_hold_time': DiscreteParameter((None, 45.0)),
+        'rules': ListParameter(
             slots=(
                 GroupParameter(
                     params={
-                        "condition": DiscreteParameter((PriorityConditionType.SOURCE_FILL_ABOVE,)),
-                        "threshold": DiscreteParameter((0.4, 0.65)),
-                        "priority": DiscreteParameter((1,)),
+                        'condition': DiscreteParameter((PriorityConditionType.SOURCE_FILL_ABOVE,)),
+                        'threshold': DiscreteParameter((0.4, 0.65)),
+                        'priority': DiscreteParameter((1,)),
                     },
                     optional=True,
                 ),
                 GroupParameter(
                     params={
-                        "condition": DiscreteParameter((PriorityConditionType.SOURCE_FILL_ABOVE,)),
-                        "threshold": DiscreteParameter((0.7, 0.85)),
-                        "priority": DiscreteParameter((0,)),
+                        'condition': DiscreteParameter((PriorityConditionType.SOURCE_FILL_ABOVE,)),
+                        'threshold': DiscreteParameter((0.7, 0.85)),
+                        'priority': DiscreteParameter((0,)),
                     },
                     optional=True,
                 ),
@@ -106,15 +110,17 @@ retrofitted_to_parking_parameter = GroupParameter(
     optional=True,
 )
 
-selection_strategy_parameter = DiscreteParameter((
-    SelectionStrategy.LEAST_OCCUPIED,
-    # SelectionStrategy.MOST_AVAILABLE, semantically equivalent to LEAST_OCCUPIED, so not needed in search space
-    SelectionStrategy.FIRST_AVAILABLE,
-    SelectionStrategy.ROUND_ROBIN,
-    SelectionStrategy.RANDOM,
-    SelectionStrategy.BEST_FIT,
-    SelectionStrategy.SHORTEST_QUEUE,
-))
+selection_strategy_parameter = DiscreteParameter(
+    (
+        SelectionStrategy.LEAST_OCCUPIED,
+        # SelectionStrategy.MOST_AVAILABLE, semantically equivalent to LEAST_OCCUPIED, so not needed in search space
+        SelectionStrategy.FIRST_AVAILABLE,
+        SelectionStrategy.ROUND_ROBIN,
+        SelectionStrategy.RANDOM,
+        SelectionStrategy.BEST_FIT,
+        SelectionStrategy.SHORTEST_QUEUE,
+    )
+)
 
 parameter_config = GroupParameter(
     optional=False,
@@ -124,14 +130,14 @@ parameter_config = GroupParameter(
         # "retrofitted_selection_strategy": selection_strategy_parameter,
         # "workshop_selection_strategy": selection_strategy_parameter,
         # "parking_selection_strategy": selection_strategy_parameter,
-        "task_priorities": GroupParameter(
+        'task_priorities': GroupParameter(
             optional=False,
             params={
-                "collection_to_retrofit": collection_to_retrofit_parameter,
-                "retrofit_to_workshop": retrofit_to_workshop_parameter,
-                "workshop_to_retrofitted": workshop_to_retrofitted_parameter,
-                "retrofitted_to_parking": retrofitted_to_parking_parameter,
-            }
+                'collection_to_retrofit': collection_to_retrofit_parameter,
+                'retrofit_to_workshop': retrofit_to_workshop_parameter,
+                'workshop_to_retrofitted': workshop_to_retrofitted_parameter,
+                'retrofitted_to_parking': retrofitted_to_parking_parameter,
+            },
         )
-    }
+    },
 )

--- a/popupsim/backend/src/optimizer/search.py
+++ b/popupsim/backend/src/optimizer/search.py
@@ -1,0 +1,226 @@
+"""Two-phase adaptive coordinate search over scenario parameters.
+
+Phase 1 draws a pool of random configurations and evaluates them in parallel.
+Phase 2 runs coordinate descent from the best elites, varying one task-priority
+field at a time. Every evaluated configuration is cached in an
+:class:`EvalRecord` keyed by a canonical JSON representation so duplicates are
+never simulated twice.
+"""
+
+import copy
+from dataclasses import dataclass
+from dataclasses import field
+import json
+from pathlib import Path
+import random
+from typing import Any
+
+from contexts.configuration.domain.models.scenario import Scenario
+from optimizer.harness import run_parallel
+from optimizer.harness import run_simulation
+from optimizer.parameter_model import GroupParameter
+from optimizer.problem_space import parameter_config
+from optimizer.util import convert
+from optimizer.util import get_neighbors
+
+TASK_NAMES = (
+    'collection_to_retrofit',
+    'retrofit_to_workshop',
+    'workshop_to_retrofitted',
+    'retrofitted_to_parking',
+)
+
+
+@dataclass(frozen=True)
+class SearchConfig:
+    """Tuning knobs and scoring weights for an optimization run."""
+
+    seed: int = 42
+    n_random: int = 500
+    k_starts: int = 5
+    max_rounds: int = 5
+    weight_completion: float = 0.9
+    weight_loco: float = -0.1
+    n_workers: int | None = None
+
+
+@dataclass(frozen=True)
+class EvalRecord:
+    """Evaluated configuration with its score and headline metrics."""
+
+    score: float
+    completion_rate_pct: float
+    loco_utilization_pct: float
+    params: dict[str, Any]
+
+
+@dataclass
+class OptimizationResult:
+    """Outcome of an optimization run."""
+
+    initial: EvalRecord
+    records: dict[str, EvalRecord] = field(default_factory=dict)
+
+    def ranked(self) -> list[EvalRecord]:
+        """Return all evaluated records sorted by descending score."""
+        return sorted(self.records.values(), key=lambda r: r.score, reverse=True)
+
+
+def _serialize_enums(obj: Any) -> Any:
+    """Recursively replace enum values with their ``.value`` for JSON output."""
+    if isinstance(obj, dict):
+        return {k: _serialize_enums(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_serialize_enums(x) for x in obj]
+    if hasattr(obj, 'value'):
+        return obj.value
+    return obj
+
+
+def config_key(params: dict[str, Any]) -> str:
+    """Return a canonical, order-independent string key for a configuration."""
+    return json.dumps(_serialize_enums(params), sort_keys=True)
+
+
+def _initial_record(scenario: Scenario, scenario_dir: Path, config: SearchConfig) -> EvalRecord:
+    """Evaluate the unmodified scenario and return its record."""
+    summary, score, _scenario = run_simulation(
+        scenario_dir, weight_completion=config.weight_completion, weight_loco=config.weight_loco
+    )
+    params = {
+        'task_priorities': {
+            name: (dto.model_dump() if dto is not None else None) for name, dto in scenario.task_priorities.items()
+        }
+    }
+    return EvalRecord(score, summary.completion_rate_pct, summary.loco_utilization_pct, params)
+
+
+def _sample_pool(rng: random.Random, n_random: int, seen: dict[str, EvalRecord]) -> list[dict[str, Any]]:
+    """Draw up to ``n_random`` unique, unseen configurations from the search space."""
+    samples: list[dict[str, Any]] = []
+    seen_in_pool: set[str] = set()
+    attempts = 0
+    while len(samples) < n_random and attempts < n_random * 10:
+        attempts += 1
+        candidate = parameter_config.sample_value(rng)
+        if candidate is None:
+            raise RuntimeError('Failed to sample parameters. Top-level parameters must not be optional.')
+        key = config_key(candidate)
+        if key in seen or key in seen_in_pool:
+            continue
+        seen_in_pool.add(key)
+        samples.append(candidate)
+    return samples
+
+
+def _evaluate_batch(
+    scenario: Scenario,
+    scenario_dir: Path,
+    params_batch: list[dict[str, Any]],
+    config: SearchConfig,
+) -> dict[str, EvalRecord]:
+    """Run a batch of configurations in parallel and return their records by key."""
+    scenarios = [convert(params, scenario) for params in params_batch]
+    results = run_parallel(
+        scenario_dir,
+        scenarios,
+        weight_completion=config.weight_completion,
+        weight_loco=config.weight_loco,
+        max_workers=config.n_workers,
+    )
+    records: dict[str, EvalRecord] = {}
+    for params, result in zip(params_batch, results, strict=True):
+        if result is None:
+            continue
+        summary, score, _scenario = result
+        records[config_key(params)] = EvalRecord(
+            score, summary.completion_rate_pct, summary.loco_utilization_pct, params
+        )
+    return records
+
+
+def _task_config() -> GroupParameter:
+    """Return the task-priorities sub-parameter of the search space."""
+    task_priorities = parameter_config.params['task_priorities']
+    if not isinstance(task_priorities, GroupParameter):
+        raise TypeError("Expected 'task_priorities' to be a GroupParameter in the search space.")
+    return task_priorities
+
+
+def _neighbor_configs(current: dict[str, Any], task_name: str) -> list[dict[str, Any]]:
+    """Return configurations that differ from ``current`` in one task's value."""
+    task_param = _task_config().params[task_name]
+    task_val = current['task_priorities'][task_name]
+    neighbors: list[dict[str, Any]] = []
+    for task_neighbor in get_neighbors(task_param, task_val):
+        candidate = copy.deepcopy(current)
+        candidate['task_priorities'][task_name] = task_neighbor
+        neighbors.append(candidate)
+    return neighbors
+
+
+def _descend_from(
+    scenario: Scenario,
+    scenario_dir: Path,
+    start: EvalRecord,
+    config: SearchConfig,
+    seen: dict[str, EvalRecord],
+) -> None:
+    """Run coordinate descent from ``start``, recording every evaluation in ``seen``."""
+    current_params = start.params
+    current_score = start.score
+    for _round in range(config.max_rounds):
+        improved = False
+        for task_name in TASK_NAMES:
+            neighbors = _neighbor_configs(current_params, task_name)
+            unseen = [c for c in neighbors if config_key(c) not in seen]
+            if unseen:
+                seen.update(_evaluate_batch(scenario, scenario_dir, unseen, config))
+
+            best = max(
+                (seen[config_key(c)] for c in neighbors if config_key(c) in seen),
+                key=lambda r: r.score,
+                default=None,
+            )
+            if best is not None and best.score > current_score:
+                current_params = best.params
+                current_score = best.score
+                improved = True
+        if not improved:
+            break
+
+
+def optimize_scenario(scenario_dir: Path, config: SearchConfig | None = None) -> OptimizationResult:
+    """Optimize a scenario with random search followed by coordinate descent."""
+    config = config or SearchConfig()
+    scenario = Scenario.model_validate_json((scenario_dir / 'scenario.json').read_text(encoding='utf-8'))
+
+    initial = _initial_record(scenario, scenario_dir, config)
+    seen: dict[str, EvalRecord] = {config_key(initial.params): initial}
+
+    rng = random.Random(config.seed)  # noqa: S311 - search sampling, not security-sensitive
+    pool = _sample_pool(rng, config.n_random, seen)
+    seen.update(_evaluate_batch(scenario, scenario_dir, pool, config))
+
+    initial_key = config_key(initial.params)
+    elites = [r for r in seen.values() if config_key(r.params) != initial_key]
+    elites.sort(key=lambda r: r.score, reverse=True)
+    for start in elites[: config.k_starts]:
+        _descend_from(scenario, scenario_dir, start, config, seen)
+
+    return OptimizationResult(initial=initial, records=seen)
+
+
+def write_results(result: OptimizationResult, results_json: Path) -> None:
+    """Write all evaluated configurations to ``results_json`` sorted by score."""
+    payload = [
+        {
+            'parameters': _serialize_enums(record.params),
+            'completion': record.completion_rate_pct,
+            'loco_utilization': record.loco_utilization_pct,
+            'score': record.score,
+        }
+        for record in result.ranked()
+    ]
+    results_json.parent.mkdir(parents=True, exist_ok=True)
+    results_json.write_text(json.dumps(payload, indent=2), encoding='utf-8')

--- a/popupsim/backend/src/optimizer/summary_model.py
+++ b/popupsim/backend/src/optimizer/summary_model.py
@@ -1,4 +1,7 @@
-from pydantic import BaseModel, Field
+"""Typed models for the summary_metrics.json produced by the simulation."""
+
+from pydantic import BaseModel
+from pydantic import Field
 
 
 class WorkshopStats(BaseModel):
@@ -74,12 +77,12 @@ class SummaryMetrics(BaseModel):
 
     @property
     def completion_rate_pct(self) -> float:
-        """Percentage of processable wagons that were fully retrofitted and parked (0–100)."""
+        """Percentage of processable wagons that were fully retrofitted and parked (0-100)."""
         return self.completion_rate * 100.0
 
     @property
     def loco_utilization_pct(self) -> float:
-        """Average locomotive utilisation as a percentage of total available time (0–100).
+        """Average locomotive utilisation as a percentage of total available time (0-100).
 
         Active time per loco = moving_time + coupling_time + decoupling_time (excludes idle).
         Each locomotive is weighted equally.
@@ -87,8 +90,5 @@ class SummaryMetrics(BaseModel):
         n_locos = len(self.locomotive_time_breakdown)
         if n_locos == 0 or self.simulation_duration_minutes == 0:
             return 0.0
-        total_active = sum(
-            locomotive.moving_time
-            for locomotive in self.locomotive_time_breakdown.values()
-        )
+        total_active = sum(locomotive.moving_time for locomotive in self.locomotive_time_breakdown.values())
         return (total_active / n_locos) / self.simulation_duration_minutes * 100.0

--- a/popupsim/backend/src/optimizer/util.py
+++ b/popupsim/backend/src/optimizer/util.py
@@ -1,39 +1,39 @@
+"""Helper utilities for the optimizer: scoring, type coercion and neighbor generation."""
 
 from enum import Enum
 import types
-from typing import Any, Union, get_args, get_origin
+from typing import Any
+from typing import Union
+from typing import get_args
+from typing import get_origin
 
-from contexts.configuration.application.dtos import (
-    HoldConditionInputDTO,
-    PriorityRuleInputDTO,
-    TaskPriorityInputDTO,
-)
+from contexts.configuration.application.dtos import HoldConditionInputDTO
+from contexts.configuration.application.dtos import PriorityRuleInputDTO
+from contexts.configuration.application.dtos import TaskPriorityInputDTO
 from contexts.configuration.domain.models.scenario import Scenario
+from optimizer.parameter_model import ContinuousParameter
+from optimizer.parameter_model import DiscreteParameter
+from optimizer.parameter_model import GroupParameter
+from optimizer.parameter_model import ListParameter
+from optimizer.parameter_model import Parameter
+from optimizer.parameter_model import _make_canonical
+from optimizer.parameter_model import _safe_sort_key
 from optimizer.summary_model import SummaryMetrics
 
 
-
-from optimizer.parameter_model import (
-    Parameter,
-    GroupParameter,
-    ListParameter,
-    DiscreteParameter,
-    ContinuousParameter,
-    _make_canonical,
-    _safe_sort_key,
-)
-
 def score(summary: SummaryMetrics, weight_completion: float = 0.9, weight_loco: float = -0.1) -> float:
+    """Return the weighted objective score for a simulation summary."""
     return summary.completion_rate_pct * weight_completion + summary.loco_utilization_pct * weight_loco
 
 
 def _get_underlying_type(annotation: Any) -> Any:
+    """Return the non-None type of an ``Optional``/union annotation, else the annotation."""
     origin = get_origin(annotation)
-    UnionType = getattr(types, "UnionType", None)
-    if origin is Union or (UnionType is not None and origin is UnionType):
+    union_type = getattr(types, 'UnionType', None)
+    if origin is Union or (union_type is not None and origin is union_type):
         args = get_args(annotation)
-        # Filter out NoneType
-        non_none_args = [arg for arg in args if arg is not type(None)]
+        none_type = type(None)
+        non_none_args = [arg for arg in args if arg is not none_type]
         if len(non_none_args) == 1:
             return non_none_args[0]
     return annotation
@@ -52,139 +52,140 @@ def _coerce_value(value: Any, expected_type: Any) -> Any:
     return value
 
 
-def _to_task_priority(val: Any) -> TaskPriorityInputDTO | None:
-    if val is None:
+def _to_hold_condition(raw: Any) -> HoldConditionInputDTO | None:
+    """Build a HoldConditionInputDTO from a raw dict or pass through an existing one."""
+    if raw is None:
         return None
-    if isinstance(val, TaskPriorityInputDTO):
-        return val
-    if isinstance(val, dict):
-        base_priority = val.get("base_priority", 3)
-        max_hold_time = val.get("max_hold_time")
-
-        hold_until = None
-        hold_until_val = val.get("hold_until")
-        if hold_until_val is not None:
-            if isinstance(hold_until_val, HoldConditionInputDTO):
-                hold_until = hold_until_val
-            elif isinstance(hold_until_val, dict):
-                hold_until = HoldConditionInputDTO(
-                    condition=str(hold_until_val["condition"]),
-                    threshold=float(hold_until_val.get("threshold", 0.0)),
-                )
-
-        rules = []
-        rules_val = val.get("rules")
-        if rules_val is not None:
-            for r in rules_val:
-                if r is None:
-                    continue
-                if isinstance(r, PriorityRuleInputDTO):
-                    rules.append(r)
-                elif isinstance(r, dict):
-                    rules.append(
-                        PriorityRuleInputDTO(
-                            condition=str(r["condition"]),
-                            threshold=float(r.get("threshold", 0.0)),
-                            priority=int(r["priority"]),
-                        )
-                    )
-
-        return TaskPriorityInputDTO(
-            base_priority=int(base_priority),
-            rules=rules,
-            hold_until=hold_until,
-            max_hold_time=float(max_hold_time) if max_hold_time is not None else None,
+    if isinstance(raw, HoldConditionInputDTO):
+        return raw
+    if isinstance(raw, dict):
+        return HoldConditionInputDTO(
+            condition=str(raw['condition']),
+            threshold=float(raw.get('threshold', 0.0)),
         )
     return None
 
 
-def convert(parameter_overwrite: dict[str, Any], scenario: Scenario) -> Scenario:
-    updates = {}
-    model_fields = Scenario.model_fields
+def _to_priority_rules(raw: Any) -> list[PriorityRuleInputDTO]:
+    """Build a list of PriorityRuleInputDTO from a raw iterable of dicts/DTOs."""
+    if raw is None:
+        return []
+    rules: list[PriorityRuleInputDTO] = []
+    for item in raw:
+        if isinstance(item, PriorityRuleInputDTO):
+            rules.append(item)
+        elif isinstance(item, dict):
+            rules.append(
+                PriorityRuleInputDTO(
+                    condition=str(item['condition']),
+                    threshold=float(item.get('threshold', 0.0)),
+                    priority=int(item['priority']),
+                )
+            )
+    return rules
 
-    for k, v in parameter_overwrite.items():
-        if k == "task_priorities":
-            if v is None:
-                updates["task_priorities"] = {}
-            elif isinstance(v, dict):
-                new_priorities = dict(scenario.task_priorities or {})
-                for task_type, p_val in v.items():
-                    if p_val is None:
-                        new_priorities.pop(task_type, None)
-                    else:
-                        dto = _to_task_priority(p_val)
-                        if dto is not None:
-                            new_priorities[task_type] = dto
-                updates["task_priorities"] = new_priorities
-            else:
-                updates["task_priorities"] = v
+
+def _to_task_priority(val: Any) -> TaskPriorityInputDTO | None:
+    """Coerce a raw value into a TaskPriorityInputDTO, returning None when not possible."""
+    if val is None:
+        return None
+    if isinstance(val, TaskPriorityInputDTO):
+        return val
+    if not isinstance(val, dict):
+        return None
+
+    max_hold_time = val.get('max_hold_time')
+    return TaskPriorityInputDTO(
+        base_priority=int(val.get('base_priority', 3)),
+        rules=_to_priority_rules(val.get('rules')),
+        hold_until=_to_hold_condition(val.get('hold_until')),
+        max_hold_time=float(max_hold_time) if max_hold_time is not None else None,
+    )
+
+
+def _merge_task_priorities(current: dict[str, Any] | None, overwrite: Any) -> Any:
+    """Merge a ``task_priorities`` overwrite onto the current mapping."""
+    if overwrite is None:
+        return {}
+    if not isinstance(overwrite, dict):
+        return overwrite
+    merged = dict(current or {})
+    for task_type, raw in overwrite.items():
+        if raw is None:
+            merged.pop(task_type, None)
+            continue
+        dto = _to_task_priority(raw)
+        if dto is not None:
+            merged[task_type] = dto
+    return merged
+
+
+def convert(parameter_overwrite: dict[str, Any], scenario: Scenario) -> Scenario:
+    """Apply a parameter override mapping onto ``scenario`` and return the updated copy."""
+    updates: dict[str, Any] = {}
+    model_fields = type(scenario).model_fields
+
+    for key, value in parameter_overwrite.items():
+        if key == 'task_priorities':
+            updates[key] = _merge_task_priorities(scenario.task_priorities, value)
+        elif key in model_fields:
+            underlying = _get_underlying_type(model_fields[key].annotation)
+            updates[key] = _coerce_value(value, underlying) if underlying is not None else value
         else:
-            if k in model_fields:
-                ann = model_fields[k].annotation
-                underlying = _get_underlying_type(ann)
-                if underlying is not None:
-                    updates[k] = _coerce_value(v, underlying)
-                else:
-                    updates[k] = v
-            else:
-                updates[k] = v
+            updates[key] = value
 
     return scenario.model_copy(update=updates)
+
+
+def _group_neighbors(param: GroupParameter, current_val: Any) -> list[Any]:
+    """Return neighbors of a GroupParameter value by varying one sub-field at a time."""
+    neighbors: list[Any] = []
+    if current_val is None:
+        first = next((val for val in param.iter_values() if val is not None), None)
+        if first is not None:
+            neighbors.append(first)
+        return neighbors
+
+    if param.optional:
+        neighbors.append(None)
+
+    for key, sub_param in param.params.items():
+        for sub_neighbor in get_neighbors(sub_param, current_val.get(key)):
+            new_val = dict(current_val)
+            new_val[key] = sub_neighbor
+            neighbors.append(new_val)
+    return neighbors
+
+
+def _list_neighbors(param: ListParameter, current_val: Any) -> list[Any]:
+    """Return neighbors of a ListParameter value, deduplicated by canonical form."""
+    neighbors: list[Any] = []
+    slot_count = len(param.slots)
+    slot_vals = list(current_val) + [None] * (slot_count - len(current_val))
+
+    seen_configs: set[Any] = set()
+    for i in range(slot_count):
+        for sub_neighbor in get_neighbors(param.slots[i], slot_vals[i]):
+            new_slots = list(slot_vals)
+            new_slots[i] = sub_neighbor
+
+            filtered = [(_make_canonical(x), _safe_sort_key(_make_canonical(x)), x) for x in new_slots if x is not None]
+            filtered.sort(key=lambda item: item[1])
+            canonical_combo = tuple(item[0] for item in filtered)
+            if canonical_combo not in seen_configs:
+                seen_configs.add(canonical_combo)
+                neighbors.append([item[2] for item in filtered])
+    return neighbors
 
 
 def get_neighbors(param: Parameter[Any], current_val: Any) -> list[Any]:
     """Recursively generate neighboring values by varying exactly one sub-parameter field."""
     if isinstance(param, DiscreteParameter):
         return [v for v in param.values if v != current_val]
-
     if isinstance(param, ContinuousParameter):
         return [v for v in param.iter_values() if v != current_val]
-
     if isinstance(param, GroupParameter):
-        neighbors = []
-        if current_val is None:
-            for val in param.iter_values():
-                if val is not None:
-                    neighbors.append(val)
-                    break
-            return neighbors
-
-        if param.optional:
-            neighbors.append(None)
-
-        for k, sub_param in param.params.items():
-            sub_val = current_val.get(k)
-            for sub_neighbor in get_neighbors(sub_param, sub_val):
-                new_val = dict(current_val)
-                new_val[k] = sub_neighbor
-                neighbors.append(new_val)
-        return neighbors
-
+        return _group_neighbors(param, current_val)
     if isinstance(param, ListParameter):
-        neighbors = []
-        m = len(param.slots)
-        slot_vals = list(current_val) + [None] * (m - len(current_val))
-
-        seen_configs = set()
-        for i in range(m):
-            sub_param = param.slots[i]
-            sub_val = slot_vals[i]
-            for sub_neighbor in get_neighbors(sub_param, sub_val):
-                new_slots = list(slot_vals)
-                new_slots[i] = sub_neighbor
-
-                filtered = []
-                for x in new_slots:
-                    if x is not None:
-                        c = _make_canonical(x)
-                        k = _safe_sort_key(c)
-                        filtered.append((c, k, x))
-                filtered.sort(key=lambda item: item[1])
-                canonical_combo = tuple(item[0] for item in filtered)
-                if canonical_combo not in seen_configs:
-                    seen_configs.add(canonical_combo)
-                    neighbors.append([item[2] for item in filtered])
-        return neighbors
-
+        return _list_neighbors(param, current_val)
     return []
-

--- a/popupsim/backend/src/shared/infrastructure/simulation/engines/simpy_adapter.py
+++ b/popupsim/backend/src/shared/infrastructure/simulation/engines/simpy_adapter.py
@@ -68,7 +68,9 @@ class SimPyEngineAdapter(SimulationEnginePort):
         try:
             if inspect.isgenerator(process):
                 logger.debug('SIMPY: Scheduling generator %s at t=%.1f', process, self._env.now)
-                return self._env.process(process)
+                # SimPy expects Generator[Event, Any, Any]; our public API accepts the
+                # broader Generator[Any], which mypy cannot narrow here.
+                return self._env.process(process)  # type: ignore[arg-type]
 
             if inspect.isgeneratorfunction(process):
                 logger.debug(

--- a/popupsim/backend/tests/fixtures/scenario.json
+++ b/popupsim/backend/tests/fixtures/scenario.json
@@ -13,8 +13,6 @@
     "topology": "topology.json",
     "tracks": "tracks.json",
     "workshops": "workshops.json",
-    "yards": {
-      "test": "yard.json"
-    }
+    "yards": "yard.json"
   }
 }

--- a/popupsim/backend/tests/unit/contexts/optimizer_search/test_search_equivalence.py
+++ b/popupsim/backend/tests/unit/contexts/optimizer_search/test_search_equivalence.py
@@ -1,0 +1,251 @@
+"""Differential test: refactored optimizer.search vs the original inline algorithm.
+
+The optimization algorithm used to live inline inside ``main.optimize`` (see
+PR #431). It was extracted into :mod:`optimizer.search` during a refactor. This
+test pins the behaviour by re-implementing the *original* orchestration as an
+oracle and asserting that the refactored :func:`optimize_scenario` produces the
+identical set of evaluated configurations and the identical ranking.
+
+Both the oracle and the refactored code are driven by:
+  * the same shared search space (``parameter_config``), neighbor generation
+    (``get_neighbors``) and conversion (``convert``) — unchanged by the refactor;
+  * the same deterministic stub evaluator (no real simulations are run);
+  * the same random seed.
+
+So any divergence isolates a behavioural change in the extracted orchestration.
+"""
+
+import copy
+import random
+from typing import Any
+from typing import ClassVar
+
+from optimizer import search
+from optimizer.problem_space import parameter_config
+from optimizer.util import get_neighbors
+import pytest
+
+# ---------------------------------------------------------------------------
+# Deterministic stub evaluator
+# ---------------------------------------------------------------------------
+
+
+def _stub_score(params: dict[str, Any]) -> float:
+    """Deterministic pseudo-score derived only from the configuration contents.
+
+    Using a stable hash of the canonical key means the same configuration always
+    scores the same, and the ordering across configurations is well-defined and
+    reproducible, without running any simulation.
+    """
+    key = search.config_key(params)
+    # Map the stable digest into a bounded, deterministic float score.
+    digest = abs(hash(key))
+    return (digest % 100_000) / 1000.0
+
+
+def _key(params: dict[str, Any]) -> str:
+    return search.config_key(params)
+
+
+# ---------------------------------------------------------------------------
+# Oracle: the original inline two-phase algorithm (from origin/main, PR #431)
+# ---------------------------------------------------------------------------
+
+
+def _original_optimize(seed: int, n_random: int, k_starts: int, max_rounds: int) -> dict[str, float]:
+    """Re-implementation of the original main.optimize algorithm.
+
+    Returns a mapping of ``config_key -> score`` for every evaluated
+    configuration (the original's ``seen`` cache), which fully captures which
+    configurations were explored and their scores.
+    """
+    task_names = (
+        'collection_to_retrofit',
+        'retrofit_to_workshop',
+        'workshop_to_retrofitted',
+        'retrofitted_to_parking',
+    )
+
+    # Initial configuration: the empty task-priorities baseline used by the
+    # original (an unmodified scenario has no per-task overrides in the stub).
+    initial_params: dict[str, Any] = {'task_priorities': dict.fromkeys(task_names)}
+    seen: dict[str, float] = {_key(initial_params): _stub_score(initial_params)}
+
+    # Phase 1: random exploration
+    rng = random.Random(seed)
+    samples: list[dict[str, Any]] = []
+    attempts = 0
+    while len(samples) < n_random and attempts < n_random * 10:
+        attempts += 1
+        test = parameter_config.sample_value(rng)
+        if test is None:
+            raise RuntimeError('Failed to sample parameters.')
+        key = _key(test)
+        if key in seen or any(_key(s) == key for s in samples):
+            continue
+        samples.append(test)
+
+    rated_runs = [(_stub_score(p), p) for p in samples]
+    rated_runs.sort(key=lambda x: x[0], reverse=True)
+    for sc, param_dict in rated_runs:
+        seen[_key(param_dict)] = sc
+
+    # Phase 2: coordinate descent from top-k elites
+    starts = rated_runs[:k_starts]
+    for start_score, start_params in starts:
+        current_params = start_params
+        current_score = start_score
+        for _round in range(max_rounds):
+            improved = False
+            for task_name in task_names:
+                task_param = parameter_config.params['task_priorities'].params[task_name]
+                task_val = current_params['task_priorities'][task_name]
+                neighbors_task_val = get_neighbors(task_param, task_val)
+
+                for task_neighbor in neighbors_task_val:
+                    n_params = copy.deepcopy(current_params)
+                    n_params['task_priorities'][task_name] = task_neighbor
+                    key = _key(n_params)
+                    if key not in seen:
+                        seen[key] = _stub_score(n_params)
+
+                best_neighbor = None
+                best_neighbor_score = current_score
+                for task_neighbor in neighbors_task_val:
+                    n_params = copy.deepcopy(current_params)
+                    n_params['task_priorities'][task_name] = task_neighbor
+                    s = seen.get(_key(n_params), float('-inf'))
+                    if s > best_neighbor_score:
+                        best_neighbor_score = s
+                        best_neighbor = n_params
+                if best_neighbor is not None:
+                    current_params = best_neighbor
+                    current_score = best_neighbor_score
+                    improved = True
+            if not improved:
+                break
+
+    return seen
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / harness stubbing
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stubbed_harness(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace the search module's simulation calls with the deterministic stub.
+
+    ``optimize_scenario`` reads scenario.task_priorities and calls
+    run_simulation / run_parallel. We stub all three so the differential test is
+    fast, deterministic and simulation-free.
+    """
+
+    class _StubSummary:
+        def __init__(self, score: float) -> None:
+            # completion/loco values are irrelevant to the equivalence check;
+            # only the score drives the algorithm's decisions.
+            self.completion_rate_pct = score
+            self.loco_utilization_pct = 0.0
+
+    class _StubScenario:
+        # Matches the empty baseline the oracle uses for the initial config.
+        task_priorities: ClassVar[dict[str, Any]] = {
+            'collection_to_retrofit': None,
+            'retrofit_to_workshop': None,
+            'workshop_to_retrofitted': None,
+            'retrofitted_to_parking': None,
+        }
+
+    def fake_model_validate_json(_text: str) -> _StubScenario:
+        return _StubScenario()
+
+    def fake_run_simulation(_scenario_dir: Any, **_kwargs: Any) -> tuple[Any, float, Any]:
+        params = {'task_priorities': dict(_StubScenario.task_priorities)}
+        score = _stub_score(params)
+        return _StubSummary(score), score, None
+
+    def fake_convert(params: dict[str, Any], _scenario: Any) -> dict[str, Any]:
+        # In the stub world a "scenario" is just its params; carry them through
+        # so run_parallel can score them.
+        return params
+
+    def fake_run_parallel(_scenario_dir: Any, scenarios: list[Any], **_kwargs: Any) -> list[Any]:
+        results = []
+        for params in scenarios:
+            score = _stub_score(params)
+            results.append((_StubSummary(score), score, None))
+        return results
+
+    monkeypatch.setattr(search.Scenario, 'model_validate_json', staticmethod(fake_model_validate_json))
+    monkeypatch.setattr(search, 'run_simulation', fake_run_simulation)
+    monkeypatch.setattr(search, 'run_parallel', fake_run_parallel)
+    monkeypatch.setattr(search, 'convert', fake_convert)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+# Small budget keeps the neighbor enumeration fast while still exercising both
+# phases (random pool + multi-start coordinate descent).
+_CONFIG = search.SearchConfig(seed=42, n_random=25, k_starts=3, max_rounds=3)
+
+
+def test_refactored_matches_original_algorithm(tmp_path, stubbed_harness) -> None:
+    """Refactored optimize_scenario explores the same configs and scores as the original."""
+    (tmp_path / 'scenario.json').write_text('{}', encoding='utf-8')
+
+    result = search.optimize_scenario(tmp_path, _CONFIG)
+    refactored_seen = {key: rec.score for key, rec in result.records.items()}
+
+    oracle_seen = _original_optimize(
+        seed=_CONFIG.seed,
+        n_random=_CONFIG.n_random,
+        k_starts=_CONFIG.k_starts,
+        max_rounds=_CONFIG.max_rounds,
+    )
+
+    # Same set of evaluated configurations...
+    assert set(refactored_seen) == set(oracle_seen)
+    # ...with identical scores for each.
+    assert refactored_seen == oracle_seen
+
+
+def test_ranking_matches_original(tmp_path, stubbed_harness) -> None:
+    """The ranked ordering of configurations is identical to the original's."""
+    (tmp_path / 'scenario.json').write_text('{}', encoding='utf-8')
+
+    result = search.optimize_scenario(tmp_path, _CONFIG)
+    refactored_ranked = [(key, rec.score) for key, rec in ((search.config_key(r.params), r) for r in result.ranked())]
+
+    oracle_seen = _original_optimize(
+        seed=_CONFIG.seed,
+        n_random=_CONFIG.n_random,
+        k_starts=_CONFIG.k_starts,
+        max_rounds=_CONFIG.max_rounds,
+    )
+    oracle_ranked = sorted(oracle_seen.items(), key=lambda kv: kv[1], reverse=True)
+
+    # Compare by score sequence (ties may reorder keys, so compare scores).
+    assert [score for _, score in refactored_ranked] == [score for _, score in oracle_ranked]
+
+
+def test_optimize_is_deterministic(tmp_path, stubbed_harness) -> None:
+    """Two runs with the same seed produce identical evaluated configurations."""
+    (tmp_path / 'scenario.json').write_text('{}', encoding='utf-8')
+
+    first = search.optimize_scenario(tmp_path, _CONFIG)
+    second = search.optimize_scenario(tmp_path, _CONFIG)
+
+    assert {k: r.score for k, r in first.records.items()} == {k: r.score for k, r in second.records.items()}
+
+
+def test_no_duplicate_configurations_evaluated(tmp_path, stubbed_harness) -> None:
+    """The seen cache guarantees each configuration key is unique (no re-simulation)."""
+    (tmp_path / 'scenario.json').write_text('{}', encoding='utf-8')
+
+    result = search.optimize_scenario(tmp_path, _CONFIG)
+    keys = [search.config_key(r.params) for r in result.records.values()]
+    assert len(keys) == len(set(keys))

--- a/popupsim/backend/tests/validation/test_layered_timelines.py
+++ b/popupsim/backend/tests/validation/test_layered_timelines.py
@@ -219,7 +219,7 @@ def create_layered_scenario(
 
 
 # pylint: disable=too-many-branches
-def run_layered_test(  # noqa: PLR0912
+def run_layered_test(
     num_wagons: int,
     num_workshops: int,
     retrofit_time: float,

--- a/popupsim/backend/tests/validation/test_retrofit_workflow_scenarios.py
+++ b/popupsim/backend/tests/validation/test_retrofit_workflow_scenarios.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 def create_test_scenario(
-    num_wagons: int,  # noqa: ARG001
+    num_wagons: int,
     num_workshops: int = 1,
     retrofit_time: float = 10.0,
     workshop_bays: list[int] | None = None,
@@ -218,7 +218,7 @@ def create_test_scenario(
     return mock_scenario
 
 
-def run_timeline_test(  # noqa: PLR0912
+def run_timeline_test(
     num_wagons: int,
     num_workshops: int,
     retrofit_time: float,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,16 +105,20 @@ max-complexity = 10
 # Tests
 "popupsim/backend/tests/**/*.py" = [
     "S101",    # Allow use of assert in tests
+    "S311",    # Allow non-crypto random in tests (seeded, reproducible)
     "PLR2004", # Allow magic values in tests (common in assertions)
     "ANN201",  # Missing return type annotation for test methods (always None)
     "ANN202",  # Missing return type annotation for private functions in tests
+    "ARG001",  # Unused function arguments (pytest fixtures used for side effects)
     "ARG002",  # Unused method arguments in test fixtures
+    "D104",    # Missing docstring in test packages
     "PT012",   # pytest.raises() block complexity in tests
     "PT017",   # Found assertion on exception in except block
     "RUF043",  # Pattern metacharacters in pytest match
     "RUF059",  # Unpacked variables in tests
     "B007",    # Loop control variables in tests
     "C901",    # Complex functions in validation tests
+    "PLR0912", # Too many branches in test oracles
     "PLR0913", # Too many arguments in test functions
     "PLR0915", # Too many statements in test functions
     "E501",    # Line too long in tests
@@ -183,7 +187,7 @@ plugins = ['pydantic.mypy']
 
 # Third-party libraries without stubs
 [[tool.mypy.overrides]]
-module = ["typer.*", "simpy.*", "pytest.*", "pytest_mock.*", "numpy.*"]
+module = ["typer.*", "simpy.*", "pytest.*", "pytest_mock.*", "numpy.*", "tqdm.*"]
 ignore_missing_imports = true
 disallow_untyped_defs = false
 


### PR DESCRIPTION
## Summary
Bring the backend to a clean state under the repo's own ruff, mypy and pylint configuration by improving the code rather than suppressing warnings.

- Extract the two-phase search from main.optimize into optimizer/search.py with typed EvalRecord, SearchConfig and OptimizationResult; main.optimize is now a thin CLI wrapper.
- Tidy optimizer util/harness/parameter_model: focused helpers, PEP 695 generics, docstrings, and wire the previously unused n_workers option.
- Add a differential test asserting the refactored search explores the same configurations and ranking as the original algorithm.
- Fix the scenario.json fixture (references.yards) to match the model.
- Minor ruff/mypy fixes elsewhere; suppressions kept only where justified and documented.

## Related Issues/Tickets

## Type of Change
- [X] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Documentation
- [ ] Test improvement
- [ ] Other (please describe):

## How Has This Been Tested?
Running the full testsuite

## Checklist
- [X]  Follows conventional commit message format
- [X] Code is formatted and linted (`uv run ruff format . && uv run ruff check .`)
- [X] All tests pass (`uv run pytest`)
- [ ] Documentation updated (if needed)

## Additional Notes
